### PR TITLE
Make run timeout configurable using ENV for docker setup

### DIFF
--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -36,7 +36,7 @@ class RunCommand extends Command
         $this->addOption('skip-theme-compile', null, InputOption::VALUE_NONE, 'Skip theme compile (Should be used when the theme has been compiled before in the CI/CD)');
         $this->addOption('skip-asset-install', null, InputOption::VALUE_NONE, 'Deprecated - use --skip-assets-install instead');
         $this->addOption('skip-assets-install', null, InputOption::VALUE_NONE, 'Skip asset install (Should be used when the assets have been copied before in the CI/CD)');
-        $this->addOption('timeout', null, InputOption::VALUE_REQUIRED, 'Set script execution timeout (in seconds). Set to null to disable timeout', 300);
+        $this->addOption('timeout', null, InputOption::VALUE_REQUIRED, 'Set script execution timeout (in seconds). Set to null to disable timeout', null);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -46,7 +46,7 @@ class RunCommand extends Command
         $config = new RunConfiguration(
             skipThemeCompile: (bool) $input->getOption('skip-theme-compile'),
             skipAssetsInstall: ((bool) $input->getOption('skip-asset-install') || (bool) $input->getOption('skip-assets-install')),
-            timeout: is_numeric($timeout) ? (float) $timeout : null,
+            timeout: (float) (is_numeric($timeout) ? $timeout : EnvironmentHelper::getVariable('SHOPWARE_DEPLOYMENT_TIMEOUT', '300')),
             forceReinstallation: EnvironmentHelper::getVariable('SHOPWARE_DEPLOYMENT_FORCE_REINSTALL', '0') === '1',
         );
 


### PR DESCRIPTION
When you have a slow docker host / datebase the docker setup can run into a timeout. This command is hardwired in /setup of the image. There is no way to configure the value easily. Now it is :)

I have a change in the documentation for the deployment helper https://github.com/shopware/docs/pull/1757 and the docker image https://github.com/shopware/docker/pull/124