### PR TITLE
Improve handling of one time tasks table-creation and task marking

### DIFF
--- a/src/Command/OneTimeTaskUnmarkCommand.php
+++ b/src/Command/OneTimeTaskUnmarkCommand.php
@@ -32,9 +32,18 @@ class OneTimeTaskUnmarkCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
-        $this->oneTimeTasks->remove((string) $input->getArgument('id'));
+        $taskId = (string) $input->getArgument('id');
 
-        $io->success('One-time task mark has been removed, this script will be executed on next deployment.');
+        $tasks = $this->oneTimeTasks->getExecutedTasks();
+        if (!isset($tasks[$taskId])) {
+            $io->error('One-time task with ID ' . $input->getArgument('id') . ' has not been marked as executed before.');
+
+            return Command::FAILURE;
+        }
+
+        $this->oneTimeTasks->remove($taskId);
+
+        $io->success('One-time task with ID ' . $input->getArgument('id') . ' has been marked as not executed, this script will be executed on next deployment.');
 
         return Command::SUCCESS;
     }

--- a/tests/Command/OneTimeTaskUnmarkCommandTest.php
+++ b/tests/Command/OneTimeTaskUnmarkCommandTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Shopware\Deployment\Tests\Command;
 
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Deployment\Command\OneTimeTaskUnmarkCommand;
 use Shopware\Deployment\Services\OneTimeTasks;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
 #[CoversClass(OneTimeTaskUnmarkCommand::class)]
@@ -20,11 +22,30 @@ class OneTimeTaskUnmarkCommandTest extends TestCase
             ->expects($this->once())
             ->method('remove')
             ->with('test');
+        $taskService
+            ->expects($this->once())
+            ->method('getExecutedTasks')
+            ->willReturn(['test' => ['created_at' => '2023-10-01 00:00:00']]);
 
         $cmd = new OneTimeTaskUnmarkCommand($taskService);
         $tester = new CommandTester($cmd);
         $tester->execute(['id' => 'test']);
 
         $tester->assertCommandIsSuccessful();
+    }
+
+    public function testUnmarkMissing(): void
+    {
+        $taskService = $this->createMock(OneTimeTasks::class);
+        $taskService
+            ->expects($this->once())
+            ->method('getExecutedTasks')
+            ->willReturn([]);
+
+        $cmd = new OneTimeTaskUnmarkCommand($taskService);
+        $tester = new CommandTester($cmd);
+        $tester->execute(['id' => 'test']);
+
+        Assert::assertSame($tester->getStatusCode(), Command::FAILURE);
     }
 }

--- a/tests/Services/OneTimeTasksTest.php
+++ b/tests/Services/OneTimeTasksTest.php
@@ -41,9 +41,8 @@ class OneTimeTasksTest extends TestCase
         $processHelper->expects($this->never())->method('runAndTail');
 
         $connection = $this->createMock(Connection::class);
-        $connection->expects($this->once())->method('fetchAllAssociativeIndexed')->willThrowException(new \Exception('test'));
-
-        $connection->expects($this->once())->method('executeStatement')->with('CREATE TABLE one_time_tasks (id VARCHAR(255) PRIMARY KEY, created_at DATETIME NOT NULL)');
+        $connection->expects($this->once())->method('executeQuery')->with('SELECT 1 FROM one_time_tasks LIMIT 1');
+        $connection->expects($this->once())->method('fetchAllAssociativeIndexed')->willReturn([]);
 
         $configuration = new ProjectConfiguration();
 


### PR DESCRIPTION
Improved task unmarking, simplified DB logic, updated tests.

### Command behavior improvements

* The `OneTimeTaskUnmarkCommand` now checks if the one-time task ID exists before attempting to unmark it, returning an error if it does not.

### Database table existence handling

* New `ensureTableExists()` method to check and create the `one_time_tasks` table if needed. This method is now called in `getExecutedTasks()` and `markAsRun()`, ensuring the table always exists before querying or modifying it. [[1]](diffhunk://#diff-a2b290b439331c62b7c406eb48364899031e66c6887660b31218dc64d9e953f7L43-R53) [[2]](diffhunk://#diff-a2b290b439331c62b7c406eb48364899031e66c6887660b31218dc64d9e953f7R64-R72) [[3]](diffhunk://#diff-a2b290b439331c62b7c406eb48364899031e66c6887660b31218dc64d9e953f7R14-R15)

### Test updates

* Tested `OneTimeTaskUnmarkCommand` - now handles when task doesn't exist, returns failure status.
* Updated `OneTimeTasksTest` to match new table logic, expect query check instead of exception.
* Minor test setup tweaks, import `Assert` and `Command` for better checks.