### PR TITLE
Update ProcessHelper to use env variable for timeout

### DIFF
--- a/src/Helper/ProcessHelper.php
+++ b/src/Helper/ProcessHelper.php
@@ -17,8 +17,9 @@ class ProcessHelper
     public function __construct(
         #[Autowire('%kernel.project_dir%')]
         private readonly string $projectDir,
-        private ?float $timeout = 60,
+        private ?float $timeout = null,
     ) {
+        $this->timeout = $this->validateTimeout($timeout ?? (float) EnvironmentHelper::getVariable('SHOPWARE_DEPLOYMENT_TIMEOUT', '60'));
     }
 
     /**


### PR DESCRIPTION
Change timeout property to use environment variable with a default value.
This is a change to adapt to https://github.com/shopware/deployment-helper/blob/2a60ed3ac459f12dfa903c06c3a64e2a8a627eee/src/Command/RunCommand.php#L49