### PR TITLE
feat: add %php.bin% placeholder for hooks and scripts

### DIFF
--- a/tests/Helper/ProcessHelperTest.php
+++ b/tests/Helper/ProcessHelperTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Deployment\Tests\Helper;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Deployment\Helper\ProcessHelper;
+
+#[CoversClass(ProcessHelper::class)]
+class ProcessHelperTest extends TestCase
+{
+    public function testRunAndTailReplacesPhpBinPlaceholder(): void
+    {
+        $tempFile = tempnam(sys_get_temp_dir(), 'php_bin_test_');
+
+        try {
+            $helper = new ProcessHelper('/tmp');
+            $helper->runAndTail('echo %php.bin% > ' . $tempFile);
+
+            static::assertFileExists($tempFile);
+            static::assertStringContainsString(\PHP_BINARY, (string) file_get_contents($tempFile));
+        } finally {
+            @unlink($tempFile);
+        }
+    }
+}


### PR DESCRIPTION
Adds support for a %php.bin% placeholder in hook commands and one-time task scripts. This placeholder is replaced with PHP_BINARY, ensuring the correct PHP version is used when multiple PHP versions are available on the server.

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)