### PR TITLE
feat: Add more debug information for JsonException

### DIFF
--- a/src/Services/InstallationManager.php
+++ b/src/Services/InstallationManager.php
@@ -88,10 +88,10 @@ class InstallationManager
         $this->state->disableFirstRunWizard();
 
         $this->processHelper->console(['plugin:refresh']);
-        $this->pluginHelper->installPlugins($configuration->skipAssetsInstall);
-        $this->pluginHelper->updatePlugins($configuration->skipAssetsInstall);
-        $this->pluginHelper->deactivatePlugins($configuration->skipAssetsInstall);
-        $this->pluginHelper->removePlugins($configuration->skipAssetsInstall);
+        $this->pluginHelper->installPlugins($output, $configuration->skipAssetsInstall);
+        $this->pluginHelper->updatePlugins($output, $configuration->skipAssetsInstall);
+        $this->pluginHelper->deactivatePlugins($output, $configuration->skipAssetsInstall);
+        $this->pluginHelper->removePlugins($output, $configuration->skipAssetsInstall);
 
         if ($this->configuration->store->licenseDomain !== '') {
             $this->accountService->refresh(new SymfonyStyle(new ArgvInput([]), $output), $this->state->getCurrentVersion(), $this->configuration->store->licenseDomain);

--- a/src/Services/PluginHelper.php
+++ b/src/Services/PluginHelper.php
@@ -6,6 +6,7 @@ namespace Shopware\Deployment\Services;
 
 use Shopware\Deployment\Config\ProjectConfiguration;
 use Shopware\Deployment\Helper\ProcessHelper;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class PluginHelper
 {
@@ -16,7 +17,7 @@ class PluginHelper
     ) {
     }
 
-    public function installPlugins(bool $skipAssetsInstall = false): void
+    public function installPlugins(OutputInterface $output, bool $skipAssetsInstall = false): void
     {
         $additionalParameters = [];
 
@@ -24,7 +25,7 @@ class PluginHelper
             $additionalParameters[] = '--skip-asset-build';
         }
 
-        foreach ($this->pluginLoader->all() as $plugin) {
+        foreach ($this->pluginLoader->all($output) as $plugin) {
             if (!$this->configuration->extensionManagement->canExtensionBeInstalled($plugin['name'])) {
                 continue;
             }
@@ -52,7 +53,7 @@ class PluginHelper
         }
     }
 
-    public function updatePlugins(bool $skipAssetsInstall = false): void
+    public function updatePlugins(OutputInterface $output, bool $skipAssetsInstall = false): void
     {
         $additionalParameters = [];
 
@@ -60,7 +61,7 @@ class PluginHelper
             $additionalParameters[] = '--skip-asset-build';
         }
 
-        foreach ($this->pluginLoader->all() as $plugin) {
+        foreach ($this->pluginLoader->all($output) as $plugin) {
             if (!$this->configuration->extensionManagement->canExtensionBeInstalled($plugin['name'])) {
                 continue;
             }
@@ -78,7 +79,7 @@ class PluginHelper
         }
     }
 
-    public function deactivatePlugins(bool $skipAssetsInstall = false): void
+    public function deactivatePlugins(OutputInterface $output, bool $skipAssetsInstall = false): void
     {
         $additionalParameters = [];
 
@@ -86,7 +87,7 @@ class PluginHelper
             $additionalParameters[] = '--skip-asset-build';
         }
 
-        foreach ($this->pluginLoader->all() as $plugin) {
+        foreach ($this->pluginLoader->all($output) as $plugin) {
             if ($plugin['installedAt'] === null || !$plugin['active'] || !$this->configuration->extensionManagement->canExtensionBeDeactivated($plugin['name'])) {
                 continue;
             }
@@ -95,7 +96,7 @@ class PluginHelper
         }
     }
 
-    public function removePlugins(bool $skipAssetsInstall = false): void
+    public function removePlugins(OutputInterface $output, bool $skipAssetsInstall = false): void
     {
         $additionalParameters = [];
 
@@ -103,7 +104,7 @@ class PluginHelper
             $additionalParameters[] = '--skip-asset-build';
         }
 
-        foreach ($this->pluginLoader->all() as $plugin) {
+        foreach ($this->pluginLoader->all($output) as $plugin) {
             if ($plugin['installedAt'] === null || !$this->configuration->extensionManagement->canExtensionBeRemoved($plugin['name'])) {
                 continue;
             }

--- a/src/Services/PluginLoader.php
+++ b/src/Services/PluginLoader.php
@@ -7,6 +7,7 @@ namespace Shopware\Deployment\Services;
 use Digilist\DependencyGraph\DependencyGraph;
 use Digilist\DependencyGraph\DependencyNode;
 use Shopware\Deployment\Helper\ProcessHelper;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Filesystem\Path;
 
@@ -25,13 +26,13 @@ class PluginLoader
     /**
      * @return array<string, Plugin>
      */
-    public function all(): array
+    public function all(OutputInterface $output): array
     {
         $projectLockPath = Path::join($this->projectDir, 'composer.lock');
         $projectAliases = [];
 
-        if (file_exists($projectLockPath)) {
-            $lockData = json_decode((string) file_get_contents($projectLockPath), true, 512, \JSON_THROW_ON_ERROR);
+        if (is_file($projectLockPath)) {
+            $lockData = json_decode((string) file_get_contents($projectLockPath), true, flags: \JSON_THROW_ON_ERROR);
 
             foreach ($lockData['packages'] as $package) {
                 if (isset($package['replace'])) {
@@ -42,7 +43,15 @@ class PluginLoader
             }
         }
 
-        $data = json_decode($this->processHelper->getPluginList(), true, 512, \JSON_THROW_ON_ERROR);
+        $pluginJsonString = $this->processHelper->getPluginList();
+        try {
+            $data = json_decode($pluginJsonString, true, flags: \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            $output->writeln('<error>Unable to parse plugin list. Error: ' . $e->getMessage() . '</error>');
+            $output->writeln('<error>Invalid JSON string: ' . $pluginJsonString . '</error>');
+
+            return [];
+        }
 
         $graph = new DependencyGraph();
         $byName = [];
@@ -57,8 +66,8 @@ class PluginLoader
         foreach ($data as $item) {
             $composerJson = Path::join($this->projectDir, $item['path'], 'composer.json');
 
-            if (file_exists($composerJson)) {
-                $composer = json_decode((string) file_get_contents($composerJson), true, 512, \JSON_THROW_ON_ERROR);
+            if (is_file($composerJson)) {
+                $composer = json_decode((string) file_get_contents($composerJson), true, flags: \JSON_THROW_ON_ERROR);
 
                 if (isset($composer['require'])) {
                     foreach ($composer['require'] as $require => $version) {

--- a/src/Services/UpgradeManager.php
+++ b/src/Services/UpgradeManager.php
@@ -86,10 +86,10 @@ class UpgradeManager
         $this->processHelper->console(['scheduled-task:register']);
         $this->processHelper->console(['messenger:stop-workers']);
 
-        $this->pluginHelper->installPlugins($configuration->skipAssetsInstall);
-        $this->pluginHelper->updatePlugins($configuration->skipAssetsInstall);
-        $this->pluginHelper->deactivatePlugins($configuration->skipAssetsInstall);
-        $this->pluginHelper->removePlugins($configuration->skipAssetsInstall);
+        $this->pluginHelper->installPlugins($output, $configuration->skipAssetsInstall);
+        $this->pluginHelper->updatePlugins($output, $configuration->skipAssetsInstall);
+        $this->pluginHelper->deactivatePlugins($output, $configuration->skipAssetsInstall);
+        $this->pluginHelper->removePlugins($output, $configuration->skipAssetsInstall);
 
         if ($this->configuration->store->licenseDomain !== '') {
             $this->accountService->refresh(new SymfonyStyle(new ArgvInput([]), $output), $currentVersion, $this->configuration->store->licenseDomain);

--- a/tests/Services/PluginHelperTest.php
+++ b/tests/Services/PluginHelperTest.php
@@ -12,6 +12,7 @@ use Shopware\Deployment\Config\ProjectExtensionManagement;
 use Shopware\Deployment\Helper\ProcessHelper;
 use Shopware\Deployment\Services\PluginHelper;
 use Shopware\Deployment\Services\PluginLoader;
+use Symfony\Component\Console\Output\BufferedOutput;
 
 #[CoversClass(PluginHelper::class)]
 class PluginHelperTest extends TestCase
@@ -30,7 +31,7 @@ class PluginHelperTest extends TestCase
             $configuration,
         );
 
-        $helper->installPlugins();
+        $helper->installPlugins(new BufferedOutput());
     }
 
     public function testInstallActiveSkipped(): void
@@ -44,7 +45,7 @@ class PluginHelperTest extends TestCase
             new ProjectConfiguration(),
         );
 
-        $helper->installPlugins();
+        $helper->installPlugins(new BufferedOutput());
     }
 
     public function testInstallNotInstalled(): void
@@ -58,7 +59,7 @@ class PluginHelperTest extends TestCase
             new ProjectConfiguration(),
         );
 
-        $helper->installPlugins();
+        $helper->installPlugins(new BufferedOutput());
     }
 
     public function testInstallNotInstalledSkipAssets(): void
@@ -72,7 +73,7 @@ class PluginHelperTest extends TestCase
             new ProjectConfiguration(),
         );
 
-        $helper->installPlugins(true);
+        $helper->installPlugins(new BufferedOutput(), true);
     }
 
     public function testInstalledButNotActive(): void
@@ -86,7 +87,7 @@ class PluginHelperTest extends TestCase
             new ProjectConfiguration(),
         );
 
-        $helper->installPlugins();
+        $helper->installPlugins(new BufferedOutput());
     }
 
     public function testUpdateSkipped(): void
@@ -103,7 +104,7 @@ class PluginHelperTest extends TestCase
             $configuration,
         );
 
-        $helper->updatePlugins();
+        $helper->updatePlugins(new BufferedOutput());
     }
 
     public function testUpdateNoUpgrade(): void
@@ -117,7 +118,7 @@ class PluginHelperTest extends TestCase
             new ProjectConfiguration(),
         );
 
-        $helper->updatePlugins();
+        $helper->updatePlugins(new BufferedOutput());
     }
 
     public function testUpdateWhenForcedButSameVersion(): void
@@ -134,7 +135,7 @@ class PluginHelperTest extends TestCase
             $projectConfiguration,
         );
 
-        $helper->updatePlugins();
+        $helper->updatePlugins(new BufferedOutput());
     }
 
     public function testNoUpdateWhenNotForcedWithSameVersion(): void
@@ -150,7 +151,7 @@ class PluginHelperTest extends TestCase
             $projectConfiguration,
         );
 
-        $helper->updatePlugins();
+        $helper->updatePlugins(new BufferedOutput());
     }
 
     public function testUpdate(): void
@@ -164,7 +165,7 @@ class PluginHelperTest extends TestCase
             new ProjectConfiguration(),
         );
 
-        $helper->updatePlugins();
+        $helper->updatePlugins(new BufferedOutput());
     }
 
     public function testUpdateDisableAssetBuild(): void
@@ -178,7 +179,7 @@ class PluginHelperTest extends TestCase
             new ProjectConfiguration(),
         );
 
-        $helper->updatePlugins(true);
+        $helper->updatePlugins(new BufferedOutput(), true);
     }
 
     public function testInactive(): void
@@ -195,7 +196,7 @@ class PluginHelperTest extends TestCase
             $configuration,
         );
 
-        $helper->deactivatePlugins();
+        $helper->deactivatePlugins(new BufferedOutput());
     }
 
     public function testInactiveWithDisabledAssets(): void
@@ -212,7 +213,7 @@ class PluginHelperTest extends TestCase
             $configuration,
         );
 
-        $helper->deactivatePlugins(true);
+        $helper->deactivatePlugins(new BufferedOutput(), true);
     }
 
     public function testInactiveNotMatching(): void
@@ -228,7 +229,7 @@ class PluginHelperTest extends TestCase
             $configuration,
         );
 
-        $helper->deactivatePlugins();
+        $helper->deactivatePlugins(new BufferedOutput());
     }
 
     public function testUninstall(): void
@@ -245,7 +246,7 @@ class PluginHelperTest extends TestCase
             $configuration,
         );
 
-        $helper->removePlugins();
+        $helper->removePlugins(new BufferedOutput());
     }
 
     public function testUninstallWithDisabledAssets(): void
@@ -262,7 +263,7 @@ class PluginHelperTest extends TestCase
             $configuration,
         );
 
-        $helper->removePlugins(true);
+        $helper->removePlugins(new BufferedOutput(), true);
     }
 
     public function testUninstallWithDisabledAssetsKeepData(): void
@@ -279,7 +280,7 @@ class PluginHelperTest extends TestCase
             $configuration,
         );
 
-        $helper->removePlugins(true);
+        $helper->removePlugins(new BufferedOutput(), true);
     }
 
     public function testUninstallNotMatching(): void
@@ -295,7 +296,7 @@ class PluginHelperTest extends TestCase
             $configuration,
         );
 
-        $helper->removePlugins(true);
+        $helper->removePlugins(new BufferedOutput(), true);
     }
 
     public function getPluginLoader(bool $active = true, ?string $installedAt = 'test', ?string $upgradeVersion = null): PluginLoader&MockObject

--- a/tests/Services/PluginLoaderTest.php
+++ b/tests/Services/PluginLoaderTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Deployment\Helper\ProcessHelper;
 use Shopware\Deployment\Services\PluginLoader;
+use Symfony\Component\Console\Output\BufferedOutput;
 
 #[CoversClass(PluginLoader::class)]
 class PluginLoaderTest extends TestCase
@@ -20,10 +21,27 @@ class PluginLoaderTest extends TestCase
             ->method('getPluginList')
             ->willReturn('[{"name":"TestPlugin", "version": "1.0.0", "composerName": "test/test-plugin", "path": "custom/plugins/TestPlugin", "active": true, "installedAt": "2021-01-01 00:00:00", "upgradeVersion": "1.0.1"}]');
 
-        $plugins = (new PluginLoader(__DIR__, $processHelper))->all();
+        $plugins = (new PluginLoader(__DIR__, $processHelper))->all(new BufferedOutput());
 
         static::assertCount(1, $plugins);
         static::assertArrayHasKey('TestPlugin', $plugins);
+    }
+
+    public function testLoadWithInvalidPluginJson(): void
+    {
+        $processHelper = $this->createMock(ProcessHelper::class);
+
+        $processHelper
+            ->method('getPluginList')
+            ->willReturn('This is not a JSON string');
+
+        $output = new BufferedOutput();
+        $plugins = (new PluginLoader(__DIR__, $processHelper))->all($output);
+        self::assertSame([], $plugins);
+
+        $fetchedOutput = $output->fetch();
+        self::assertStringContainsString('Unable to parse plugin list. Error: Syntax error', $fetchedOutput);
+        self::assertStringContainsString('Invalid JSON string: This is not a JSON string', $fetchedOutput);
     }
 
     public function testLoadDependenciesInRightOrder(): void
@@ -49,7 +67,7 @@ class PluginLoaderTest extends TestCase
             ->method('getPluginList')
             ->willReturn(json_encode($data, \JSON_THROW_ON_ERROR));
 
-        $plugins = (new PluginLoader(__DIR__, $processHelper))->all();
+        $plugins = (new PluginLoader(__DIR__, $processHelper))->all(new BufferedOutput());
 
         static::assertCount(2, $plugins);
         static::assertSame(
@@ -94,7 +112,7 @@ class PluginLoaderTest extends TestCase
             ->method('getPluginList')
             ->willReturn(json_encode($data, \JSON_THROW_ON_ERROR));
 
-        $plugins = (new PluginLoader(__DIR__ . '/_fixtures', $processHelper))->all();
+        $plugins = (new PluginLoader(__DIR__ . '/_fixtures', $processHelper))->all(new BufferedOutput());
 
         static::assertCount(2, $plugins);
         static::assertSame(


### PR DESCRIPTION
if the `plugin:list` process returns an invalid JSON string, only `Syntax error` is shown on the output. 

this improves the behaviour 