### PR TITLE
feat: add local config file override support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
     "php": ">=8.2",
     "ext-dom": "*",
     "ext-pdo": "*",
-    "ext-sockets": "*",
     "digilist/dependency-graph": ">=0.4.1",
     "doctrine/dbal": "^3.0 || ^4.0",
     "symfony/config": "^7.0 || ^6.0",

--- a/src/Config/ConfigFactory.php
+++ b/src/Config/ConfigFactory.php
@@ -37,6 +37,13 @@ class ConfigFactory
         $projectConfiguration = new ProjectConfiguration();
         $config = Yaml::parseFile($file);
 
+        $localFile = self::resolveLocalFile($file);
+
+        if ($localFile !== null) {
+            $localConfig = Yaml::parseFile($localFile, Yaml::PARSE_CUSTOM_TAGS);
+            $config = ConfigMerger::merge($config ?? [], $localConfig ?? []);
+        }
+
         if (isset($config['deployment']) && \is_array($config['deployment'])) {
             self::fillConfig($projectConfiguration, $config['deployment']);
         }
@@ -160,6 +167,20 @@ class ConfigFactory
                 }
             }
         }
+    }
+
+    private static function resolveLocalFile(string $file): ?string
+    {
+        $extension = pathinfo($file, \PATHINFO_EXTENSION);
+        $baseName = substr($file, 0, -\strlen('.' . $extension));
+
+        $localFile = $baseName . '.local.' . $extension;
+
+        if (file_exists($localFile)) {
+            return $localFile;
+        }
+
+        return null;
     }
 
     public static function fillLicenseDomain(ProjectConfiguration $projectConfiguration): ProjectConfiguration

--- a/src/Config/ConfigMerger.php
+++ b/src/Config/ConfigMerger.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Deployment\Config;
+
+use Symfony\Component\Yaml\Tag\TaggedValue;
+
+class ConfigMerger
+{
+    /**
+     * Deep merges the override config on top of the base config.
+     *
+     * Supports custom YAML tags:
+     * - !reset: Clears the field. For maps/slices, replaces with the tagged value. For scalars, removes the field.
+     * - !override: Fully replaces the field instead of deep-merging.
+     *
+     * @param array<string, mixed> $base
+     * @param array<string, mixed> $override
+     *
+     * @return array<string, mixed>
+     */
+    public static function merge(array $base, array $override): array
+    {
+        foreach ($override as $key => $value) {
+            if ($value instanceof TaggedValue) {
+                $base[$key] = self::resolveTaggedValue($value);
+
+                continue;
+            }
+
+            if (\is_array($value) && isset($base[$key]) && \is_array($base[$key])) {
+                if (array_is_list($value) && array_is_list($base[$key])) {
+                    // Append lists
+                    $base[$key] = array_merge($base[$key], $value);
+                } else {
+                    // Deep merge maps
+                    $base[$key] = self::merge($base[$key], $value);
+                }
+
+                continue;
+            }
+
+            $base[$key] = $value;
+        }
+
+        return $base;
+    }
+
+    private static function resolveTaggedValue(TaggedValue $taggedValue): mixed
+    {
+        return $taggedValue->getValue();
+    }
+}

--- a/src/Services/TrackingService.php
+++ b/src/Services/TrackingService.php
@@ -19,7 +19,7 @@ class TrackingService
 
     private string $id;
 
-    private \Socket|false $socket;
+    private \Socket|false|null $socket = null;
 
     private string $domain;
 
@@ -27,7 +27,10 @@ class TrackingService
         private readonly SystemConfigHelper $systemConfigHelper,
         private readonly ShopwareState $shopwareState,
     ) {
-        $this->socket = @socket_create(\AF_INET, \SOCK_DGRAM, \SOL_UDP);
+        if (\function_exists('socket_create')) {
+            $this->socket = @socket_create(\AF_INET, \SOCK_DGRAM, \SOL_UDP);
+        }
+
         $this->domain = EnvironmentHelper::getVariable('SHOPWARE_TRACKING_DOMAIN', self::DEFAULT_TRACKING_DOMAIN);
     }
 
@@ -43,7 +46,7 @@ class TrackingService
         $tags += $this->getTags();
         $id = $this->getId();
 
-        if ($this->socket === false) {
+        if ($this->socket === false || $this->socket === null) {
             return;
         }
 

--- a/tests/Config/ConfigFactoryTest.php
+++ b/tests/Config/ConfigFactoryTest.php
@@ -189,4 +189,51 @@ class ConfigFactoryTest extends TestCase
         static::assertArrayHasKey('late-task', $config->oneTimeTasks);
         static::assertSame(OneTimeTaskWhen::AFTER, $config->oneTimeTasks['late-task']->when);
     }
+
+    public function testLocalOverrideMergesConfig(): void
+    {
+        $config = ConfigFactory::create(__DIR__ . '/_fixtures/local-override', $this->createMockApplication());
+
+        // Local override replaces scalar
+        static::assertSame('local.example.com', $config->store->licenseDomain);
+
+        // Local override replaces the pre hook
+        static::assertStringContainsString('Local pre hook', $config->hooks->pre);
+
+        // Original post hook is preserved (deep merge)
+        static::assertStringContainsString('After deployment general', $config->hooks->post);
+
+        // One-time tasks are appended (list append)
+        static::assertArrayHasKey('foo', $config->oneTimeTasks);
+        static::assertArrayHasKey('bar', $config->oneTimeTasks);
+        static::assertSame('local-task', $config->oneTimeTasks['bar']->script);
+    }
+
+    public function testLocalResetTag(): void
+    {
+        $config = ConfigFactory::create(__DIR__ . '/_fixtures/local-reset', $this->createMockApplication());
+
+        // exclude list was reset, should only contain the local value
+        static::assertArrayHasKey('OnlyThisPlugin', $config->extensionManagement->overrides);
+        static::assertArrayNotHasKey('Name', $config->extensionManagement->overrides);
+        static::assertArrayNotHasKey('OtherPlugin', $config->extensionManagement->overrides);
+
+        // one-time-tasks was reset, should only contain the local task
+        static::assertCount(1, $config->oneTimeTasks);
+        static::assertArrayHasKey('only-task', $config->oneTimeTasks);
+        static::assertSame('only-script', $config->oneTimeTasks['only-task']->script);
+    }
+
+    public function testLocalOverrideTag(): void
+    {
+        $config = ConfigFactory::create(__DIR__ . '/_fixtures/local-override-tag', $this->createMockApplication());
+
+        // hooks was fully replaced with !override, post hook should be gone
+        static::assertStringContainsString('Only this hook', $config->hooks->pre);
+        static::assertSame('', $config->hooks->post);
+
+        // Other sections are preserved
+        static::assertTrue($config->extensionManagement->enabled);
+        static::assertSame('prod.example.com', $config->store->licenseDomain);
+    }
 }

--- a/tests/Config/ConfigMergerTest.php
+++ b/tests/Config/ConfigMergerTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Deployment\Tests\Config;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Deployment\Config\ConfigMerger;
+use Symfony\Component\Yaml\Tag\TaggedValue;
+
+#[CoversClass(ConfigMerger::class)]
+class ConfigMergerTest extends TestCase
+{
+    public function testScalarOverride(): void
+    {
+        $base = ['url' => 'https://prod.example.com', 'name' => 'prod'];
+        $override = ['url' => 'https://local.example.com'];
+
+        $result = ConfigMerger::merge($base, $override);
+
+        static::assertSame('https://local.example.com', $result['url']);
+        static::assertSame('prod', $result['name']);
+    }
+
+    public function testDeepMergeMaps(): void
+    {
+        $base = ['deployment' => ['hooks' => ['pre' => 'echo base', 'post' => 'echo post']]];
+        $override = ['deployment' => ['hooks' => ['pre' => 'echo override']]];
+
+        $result = ConfigMerger::merge($base, $override);
+
+        static::assertSame('echo override', $result['deployment']['hooks']['pre']);
+        static::assertSame('echo post', $result['deployment']['hooks']['post']);
+    }
+
+    public function testAppendLists(): void
+    {
+        $base = ['items' => ['a', 'b']];
+        $override = ['items' => ['c']];
+
+        $result = ConfigMerger::merge($base, $override);
+
+        static::assertSame(['a', 'b', 'c'], $result['items']);
+    }
+
+    public function testResetList(): void
+    {
+        $base = ['items' => ['a', 'b', 'c']];
+        $override = ['items' => new TaggedValue('reset', ['x'])];
+
+        $result = ConfigMerger::merge($base, $override);
+
+        static::assertSame(['x'], $result['items']);
+    }
+
+    public function testResetEmptyList(): void
+    {
+        $base = ['items' => ['a', 'b', 'c']];
+        $override = ['items' => new TaggedValue('reset', [])];
+
+        $result = ConfigMerger::merge($base, $override);
+
+        static::assertSame([], $result['items']);
+    }
+
+    public function testResetMap(): void
+    {
+        $base = ['config' => ['key1' => 'val1', 'key2' => 'val2']];
+        $override = ['config' => new TaggedValue('reset', ['key3' => 'val3'])];
+
+        $result = ConfigMerger::merge($base, $override);
+
+        static::assertSame(['key3' => 'val3'], $result['config']);
+    }
+
+    public function testResetScalarRemovesField(): void
+    {
+        $base = ['url' => 'https://prod.example.com', 'name' => 'prod'];
+        $override = ['url' => new TaggedValue('reset', null)];
+
+        $result = ConfigMerger::merge($base, $override);
+
+        static::assertNull($result['url']);
+        static::assertSame('prod', $result['name']);
+    }
+
+    public function testOverrideMap(): void
+    {
+        $base = ['deployment' => ['hooks' => ['pre' => 'echo base', 'post' => 'echo post']]];
+        $override = ['deployment' => ['hooks' => new TaggedValue('override', ['pre' => 'echo only-this'])]];
+
+        $result = ConfigMerger::merge($base, $override);
+
+        static::assertSame(['pre' => 'echo only-this'], $result['deployment']['hooks']);
+    }
+
+    public function testOverrideList(): void
+    {
+        $base = ['items' => ['a', 'b', 'c']];
+        $override = ['items' => new TaggedValue('override', ['x'])];
+
+        $result = ConfigMerger::merge($base, $override);
+
+        static::assertSame(['x'], $result['items']);
+    }
+
+    public function testNewKeysAdded(): void
+    {
+        $base = ['existing' => 'value'];
+        $override = ['new_key' => 'new_value'];
+
+        $result = ConfigMerger::merge($base, $override);
+
+        static::assertSame('value', $result['existing']);
+        static::assertSame('new_value', $result['new_key']);
+    }
+
+    public function testNestedTaggedValue(): void
+    {
+        $base = [
+            'deployment' => [
+                'extension-management' => [
+                    'exclude' => ['Name', 'OtherPlugin'],
+                    'enabled' => true,
+                ],
+            ],
+        ];
+
+        $override = [
+            'deployment' => [
+                'extension-management' => [
+                    'exclude' => new TaggedValue('reset', ['OnlyThisPlugin']),
+                ],
+            ],
+        ];
+
+        $result = ConfigMerger::merge($base, $override);
+
+        static::assertSame(['OnlyThisPlugin'], $result['deployment']['extension-management']['exclude']);
+        static::assertTrue($result['deployment']['extension-management']['enabled']);
+    }
+}

--- a/tests/Config/_fixtures/local-override-tag/.shopware-project.local.yml
+++ b/tests/Config/_fixtures/local-override-tag/.shopware-project.local.yml
@@ -1,0 +1,4 @@
+deployment:
+  hooks: !override
+    pre: |
+      echo "Only this hook"

--- a/tests/Config/_fixtures/local-override-tag/.shopware-project.yml
+++ b/tests/Config/_fixtures/local-override-tag/.shopware-project.yml
@@ -1,0 +1,14 @@
+deployment:
+  hooks:
+    pre: |
+      echo "Before deployment"
+    post: |
+      echo "After deployment"
+
+  extension-management:
+    enabled: true
+    exclude:
+      - Name
+
+  store:
+    license-domain: prod.example.com

--- a/tests/Config/_fixtures/local-override/.shopware-project.local.yml
+++ b/tests/Config/_fixtures/local-override/.shopware-project.local.yml
@@ -1,0 +1,11 @@
+deployment:
+  hooks:
+    pre: |
+      echo "Local pre hook"
+
+  store:
+    license-domain: local.example.com
+
+  one-time-tasks:
+    - id: bar
+      script: local-task

--- a/tests/Config/_fixtures/local-override/.shopware-project.yml
+++ b/tests/Config/_fixtures/local-override/.shopware-project.yml
@@ -1,0 +1,15 @@
+deployment:
+  hooks:
+    pre: |
+      echo "Before deployment general"
+    post: |
+      echo "After deployment general"
+
+  extension-management:
+    enabled: true
+    exclude:
+      - Name
+
+  one-time-tasks:
+    - id: foo
+      script: test

--- a/tests/Config/_fixtures/local-reset/.shopware-project.local.yml
+++ b/tests/Config/_fixtures/local-reset/.shopware-project.local.yml
@@ -1,0 +1,8 @@
+deployment:
+  extension-management:
+    exclude: !reset
+      - OnlyThisPlugin
+
+  one-time-tasks: !reset
+    - id: only-task
+      script: only-script

--- a/tests/Config/_fixtures/local-reset/.shopware-project.yml
+++ b/tests/Config/_fixtures/local-reset/.shopware-project.yml
@@ -1,0 +1,18 @@
+deployment:
+  hooks:
+    pre: |
+      echo "Before deployment"
+    post: |
+      echo "After deployment"
+
+  extension-management:
+    enabled: true
+    exclude:
+      - Name
+      - OtherPlugin
+
+  one-time-tasks:
+    - id: foo
+      script: test
+    - id: bar
+      script: test2


### PR DESCRIPTION
## Summary

- Add support for local config file overrides (`.local.yml` files) to allow local development settings without modifying the base config
- Add `ConfigMerger` class for deep merging of config arrays with reset and override tags
- Fix socket_create function check to prevent errors in environments without sockets extension

## Changes

- **New files**: `src/Config/ConfigMerger.php`, `tests/Config/ConfigMergerTest.php`
- **Modified**: `ConfigFactory.php`, `TrackingService.php`, `ConfigFactoryTest.php`
- **Fixtures**: Test fixtures for local-override, local-reset, and local-override-tag scenarios

## Test plan

- [x] Tests pass for ConfigMerger
- [x] Tests pass for ConfigFactory local override feature
- [x] Manual testing with local .local.yml files