### PR TITLE
feat: rename tracking ID to telemetry ID

### DIFF
--- a/src/Services/SystemConfigHelper.php
+++ b/src/Services/SystemConfigHelper.php
@@ -40,4 +40,9 @@ class SystemConfigHelper
             $this->connection->executeStatement('INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at) VALUES (?, ?, ?, NULL, NOW())', [random_bytes(16), $key, $payload]);
         }
     }
+
+    public function delete(string $key): void
+    {
+        $this->connection->executeStatement('DELETE FROM system_config WHERE configuration_key = ? AND sales_channel_id IS NULL', [$key]);
+    }
 }

--- a/src/Services/TrackingService.php
+++ b/src/Services/TrackingService.php
@@ -8,7 +8,9 @@ use Shopware\Deployment\Helper\EnvironmentHelper;
 
 class TrackingService
 {
-    private const DEPLOYMENT_HELPER_ID = 'core.deployment_helper.id';
+    private const TELEMETRY_ID = 'core.telemetry.id';
+
+    private const LEGACY_DEPLOYMENT_HELPER_ID = 'core.deployment_helper.id';
 
     private const DEFAULT_TRACKING_DOMAIN = 'udp.usage.shopware.io';
 
@@ -63,7 +65,7 @@ class TrackingService
     public function persistId(): void
     {
         if (isset($this->id)) {
-            $this->systemConfigHelper->set(self::DEPLOYMENT_HELPER_ID, $this->id);
+            $this->systemConfigHelper->set(self::TELEMETRY_ID, $this->id);
         }
     }
 
@@ -90,14 +92,23 @@ class TrackingService
         }
 
         try {
-            $id = $this->systemConfigHelper->get(self::DEPLOYMENT_HELPER_ID);
+            $id = $this->systemConfigHelper->get(self::TELEMETRY_ID);
+
+            // Migrate from legacy key
+            if ($id === null) {
+                $id = $this->systemConfigHelper->get(self::LEGACY_DEPLOYMENT_HELPER_ID);
+
+                if ($id !== null) {
+                    $this->systemConfigHelper->set(self::TELEMETRY_ID, $id);
+                }
+            }
         } catch (\Throwable) {
             $this->id = $id = bin2hex(random_bytes(16));
         }
 
         if ($id === null) {
             $this->id = $id = bin2hex(random_bytes(16));
-            $this->systemConfigHelper->set(self::DEPLOYMENT_HELPER_ID, $id);
+            $this->systemConfigHelper->set(self::TELEMETRY_ID, $id);
         }
 
         return $this->id = $id;

--- a/src/Services/TrackingService.php
+++ b/src/Services/TrackingService.php
@@ -8,9 +8,9 @@ use Shopware\Deployment\Helper\EnvironmentHelper;
 
 class TrackingService
 {
-    private const TELEMETRY_ID = 'core.telemetry.id';
+    public const TELEMETRY_ID = 'core.telemetry.id';
 
-    private const LEGACY_DEPLOYMENT_HELPER_ID = 'core.deployment_helper.id';
+    public const LEGACY_DEPLOYMENT_HELPER_ID = 'core.deployment_helper.id';
 
     private const DEFAULT_TRACKING_DOMAIN = 'udp.usage.shopware.io';
 
@@ -100,6 +100,7 @@ class TrackingService
 
                 if ($id !== null) {
                     $this->systemConfigHelper->set(self::TELEMETRY_ID, $id);
+                    $this->systemConfigHelper->delete(self::LEGACY_DEPLOYMENT_HELPER_ID);
                 }
             }
         } catch (\Throwable) {

--- a/tests/Services/TrackingServiceTest.php
+++ b/tests/Services/TrackingServiceTest.php
@@ -24,7 +24,7 @@ class TrackingServiceTest extends TestCase
         $service = new TrackingService($systemConfigHelper, $shopwareState);
         $service->track('test_event');
 
-        $id = $systemConfigHelper->get('core.deployment_helper.id');
+        $id = $systemConfigHelper->get('core.telemetry.id');
         static::assertNotNull($id);
         static::assertMatchesRegularExpression('/^[a-f0-9]{32}$/', $id);
     }
@@ -32,14 +32,14 @@ class TrackingServiceTest extends TestCase
     public function testTrackUsesExistingIdFromConfig(): void
     {
         $systemConfigHelper = new StaticSystemConfigHelper();
-        $systemConfigHelper->set('core.deployment_helper.id', 'existing-id-123');
+        $systemConfigHelper->set('core.telemetry.id', 'existing-id-123');
         $shopwareState = $this->createMock(ShopwareState::class);
         $shopwareState->method('getCurrentVersion')->willReturn('6.6.0.0');
 
         $service = new TrackingService($systemConfigHelper, $shopwareState);
         $service->track('test_event');
 
-        static::assertSame('existing-id-123', $systemConfigHelper->get('core.deployment_helper.id'));
+        static::assertSame('existing-id-123', $systemConfigHelper->get('core.telemetry.id'));
     }
 
     public function testPersistIdDoesNothingWhenNoIdGenerated(): void
@@ -50,7 +50,20 @@ class TrackingServiceTest extends TestCase
         $service = new TrackingService($systemConfigHelper, $shopwareState);
         $service->persistId();
 
-        static::assertNull($systemConfigHelper->get('core.deployment_helper.id'));
+        static::assertNull($systemConfigHelper->get('core.telemetry.id'));
+    }
+
+    public function testTrackMigratesLegacyKey(): void
+    {
+        $systemConfigHelper = new StaticSystemConfigHelper();
+        $systemConfigHelper->set('core.deployment_helper.id', 'legacy-id-456');
+        $shopwareState = $this->createMock(ShopwareState::class);
+        $shopwareState->method('getCurrentVersion')->willReturn('6.6.0.0');
+
+        $service = new TrackingService($systemConfigHelper, $shopwareState);
+        $service->track('test_event');
+
+        static::assertSame('legacy-id-456', $systemConfigHelper->get('core.telemetry.id'));
     }
 
     #[Env('DO_NOT_TRACK')]

--- a/tests/Services/TrackingServiceTest.php
+++ b/tests/Services/TrackingServiceTest.php
@@ -24,7 +24,7 @@ class TrackingServiceTest extends TestCase
         $service = new TrackingService($systemConfigHelper, $shopwareState);
         $service->track('test_event');
 
-        $id = $systemConfigHelper->get('core.telemetry.id');
+        $id = $systemConfigHelper->get(TrackingService::TELEMETRY_ID);
         static::assertNotNull($id);
         static::assertMatchesRegularExpression('/^[a-f0-9]{32}$/', $id);
     }
@@ -32,14 +32,14 @@ class TrackingServiceTest extends TestCase
     public function testTrackUsesExistingIdFromConfig(): void
     {
         $systemConfigHelper = new StaticSystemConfigHelper();
-        $systemConfigHelper->set('core.telemetry.id', 'existing-id-123');
+        $systemConfigHelper->set(TrackingService::TELEMETRY_ID, 'existing-id-123');
         $shopwareState = $this->createMock(ShopwareState::class);
         $shopwareState->method('getCurrentVersion')->willReturn('6.6.0.0');
 
         $service = new TrackingService($systemConfigHelper, $shopwareState);
         $service->track('test_event');
 
-        static::assertSame('existing-id-123', $systemConfigHelper->get('core.telemetry.id'));
+        static::assertSame('existing-id-123', $systemConfigHelper->get(TrackingService::TELEMETRY_ID));
     }
 
     public function testPersistIdDoesNothingWhenNoIdGenerated(): void
@@ -50,20 +50,21 @@ class TrackingServiceTest extends TestCase
         $service = new TrackingService($systemConfigHelper, $shopwareState);
         $service->persistId();
 
-        static::assertNull($systemConfigHelper->get('core.telemetry.id'));
+        static::assertNull($systemConfigHelper->get(TrackingService::TELEMETRY_ID));
     }
 
     public function testTrackMigratesLegacyKey(): void
     {
         $systemConfigHelper = new StaticSystemConfigHelper();
-        $systemConfigHelper->set('core.deployment_helper.id', 'legacy-id-456');
+        $systemConfigHelper->set(TrackingService::LEGACY_DEPLOYMENT_HELPER_ID, 'legacy-id-456');
         $shopwareState = $this->createMock(ShopwareState::class);
         $shopwareState->method('getCurrentVersion')->willReturn('6.6.0.0');
 
         $service = new TrackingService($systemConfigHelper, $shopwareState);
         $service->track('test_event');
 
-        static::assertSame('legacy-id-456', $systemConfigHelper->get('core.telemetry.id'));
+        static::assertSame('legacy-id-456', $systemConfigHelper->get(TrackingService::TELEMETRY_ID));
+        static::assertNull($systemConfigHelper->get(TrackingService::LEGACY_DEPLOYMENT_HELPER_ID));
     }
 
     #[Env('DO_NOT_TRACK')]

--- a/tests/TestUtil/StaticSystemConfigHelper.php
+++ b/tests/TestUtil/StaticSystemConfigHelper.php
@@ -24,4 +24,9 @@ class StaticSystemConfigHelper extends SystemConfigHelper
     {
         $this->config[$key] = $value;
     }
+
+    public function delete(string $key): void
+    {
+        unset($this->config[$key]);
+    }
 }


### PR DESCRIPTION
## Summary

We wanna use the unique id between tools, therefore renaming to something more generalized

- Renamed `core.deployment_helper.id` config key to `core.telemetry.id`
- Added migration logic to automatically migrate existing IDs from the legacy key
- Updated tests to cover the new telemetry ID key and migration behavior

## Test plan

- [x] Test that tracking generates new telemetry ID
- [x] Test that existing telemetry ID is used from config
- [x] Test that legacy ID is migrated to new telemetry ID