### PR TITLE
fix: don't use function that only exists in doctrine/dbal v4

### DIFF
--- a/src/Integration/UsageDataConsentSubscriber.php
+++ b/src/Integration/UsageDataConsentSubscriber.php
@@ -42,10 +42,8 @@ readonly class UsageDataConsentSubscriber
             return;
         }
 
-        try {
-            $this->connection->executeQuery('SELECT 1 FROM consent_state LIMIT 1');
-        } catch (\Throwable) {
-            // consent system is not used in this version
+        $tableExists = $this->connection->createSchemaManager()->tablesExist(['consent_state']);
+        if (!$tableExists) {
             return;
         }
 

--- a/src/Integration/UsageDataConsentSubscriber.php
+++ b/src/Integration/UsageDataConsentSubscriber.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopware\Deployment\Integration;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Schema\Exception\TableDoesNotExist;
 use Shopware\Deployment\Event\PostDeploy;
 use Shopware\Deployment\Helper\EnvironmentHelper;
 use Shopware\Deployment\Services\SystemConfigHelper;
@@ -44,8 +43,8 @@ readonly class UsageDataConsentSubscriber
         }
 
         try {
-            $this->connection->createSchemaManager()->introspectTableByUnquotedName('consent_state');
-        } catch (TableDoesNotExist) {
+            $this->connection->executeQuery('SELECT 1 FROM consent_state LIMIT 1');
+        } catch (\Throwable) {
             // consent system is not used in this version
             return;
         }

--- a/src/Services/OneTimeTasks.php
+++ b/src/Services/OneTimeTasks.php
@@ -67,10 +67,11 @@ class OneTimeTasks
 
     private function ensureTableExists(): void
     {
-        try {
-            $this->connection->executeQuery('SELECT 1 FROM one_time_tasks LIMIT 1');
-        } catch (\Throwable) {
-            $this->connection->executeStatement('CREATE TABLE one_time_tasks (id VARCHAR(255) PRIMARY KEY, created_at DATETIME NOT NULL)');
+        $tableExists = $this->connection->createSchemaManager()->tablesExist(['one_time_tasks']);
+        if ($tableExists) {
+            return;
         }
+
+        $this->connection->executeStatement('CREATE TABLE one_time_tasks (id VARCHAR(255) PRIMARY KEY, created_at DATETIME NOT NULL)');
     }
 }

--- a/tests/Integration/UsageDataConsentSubscriberTest.php
+++ b/tests/Integration/UsageDataConsentSubscriberTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopware\Deployment\Tests\Integration;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -45,7 +46,9 @@ class UsageDataConsentSubscriberTest extends TestCase
             ->method('set')
             ->with('core.usageData.consentState', $consent);
 
-        $this->connection->method('executeQuery')->willThrowException(new \Exception('table not found'));
+        $schemaManager = $this->createMock(AbstractSchemaManager::class);
+        $schemaManager->method('tablesExist')->willReturn(false);
+        $this->connection->method('createSchemaManager')->willReturn($schemaManager);
         $this->connection->expects($this->never())->method('executeStatement');
 
         $event = new PostDeploy(new RunConfiguration(), new NullOutput());
@@ -99,6 +102,9 @@ class UsageDataConsentSubscriberTest extends TestCase
     {
         $_SERVER['SHOPWARE_USAGE_DATA_CONSENT'] = $consent;
 
+        $schemaManager = $this->createMock(AbstractSchemaManager::class);
+        $schemaManager->method('tablesExist')->willReturn(true);
+        $this->connection->method('createSchemaManager')->willReturn($schemaManager);
         $this->connection->expects($this->once())->method('fetchAssociative')->willReturn(false);
         $this->connection->expects($this->once())->method('executeStatement')->with(
             Assert::stringStartsWith('INSERT INTO `consent_state`'),
@@ -125,6 +131,9 @@ class UsageDataConsentSubscriberTest extends TestCase
     {
         $_SERVER['SHOPWARE_USAGE_DATA_CONSENT'] = $consent;
 
+        $schemaManager = $this->createMock(AbstractSchemaManager::class);
+        $schemaManager->method('tablesExist')->willReturn(true);
+        $this->connection->method('createSchemaManager')->willReturn($schemaManager);
         $this->connection->expects($this->once())->method('fetchAssociative')->willReturn([
             'id' => 1,
             'name' => 'backend_data',

--- a/tests/Integration/UsageDataConsentSubscriberTest.php
+++ b/tests/Integration/UsageDataConsentSubscriberTest.php
@@ -5,10 +5,6 @@ declare(strict_types=1);
 namespace Shopware\Deployment\Tests\Integration;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Schema\AbstractSchemaManager;
-use Doctrine\DBAL\Schema\Exception\TableDoesNotExist;
-use Doctrine\DBAL\Schema\Table;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -28,20 +24,12 @@ class UsageDataConsentSubscriberTest extends TestCase
 
     private Connection&MockObject $connection;
 
-    /**
-     * @var (AbstractSchemaManager<AbstractPlatform>&object&MockObject)
-     */
-    private AbstractSchemaManager&MockObject $schemaManager;
-
     private UsageDataConsentSubscriber $subscriber;
 
     protected function setUp(): void
     {
         $this->systemConfigHelper = $this->createMock(SystemConfigHelper::class);
-
         $this->connection = $this->createMock(Connection::class);
-        $this->schemaManager = $this->createMock(AbstractSchemaManager::class);
-        $this->connection->method('createSchemaManager')->willReturn($this->schemaManager);
 
         $this->subscriber = new UsageDataConsentSubscriber($this->systemConfigHelper, $this->connection);
     }
@@ -57,7 +45,7 @@ class UsageDataConsentSubscriberTest extends TestCase
             ->method('set')
             ->with('core.usageData.consentState', $consent);
 
-        $this->schemaManager->method('introspectTableByUnquotedName')->willThrowException(new TableDoesNotExist('table not found'));
+        $this->connection->method('executeQuery')->willThrowException(new \Exception('table not found'));
         $this->connection->expects($this->never())->method('executeStatement');
 
         $event = new PostDeploy(new RunConfiguration(), new NullOutput());
@@ -98,7 +86,7 @@ class UsageDataConsentSubscriberTest extends TestCase
     #[Env('SHOPWARE_USAGE_DATA_CONSENT', 'requested')]
     public function testInvokeWithRequestedStateWillNotUpdateConsentTable(): void
     {
-        $this->schemaManager->expects($this->never())->method('introspectTableByUnquotedName');
+        $this->connection->expects($this->never())->method('executeQuery');
         $this->connection->expects($this->never())->method('executeStatement');
 
         $event = new PostDeploy(new RunConfiguration(), new NullOutput());
@@ -110,11 +98,6 @@ class UsageDataConsentSubscriberTest extends TestCase
     public function testInsertNewConsentState(string $consent, string $written): void
     {
         $_SERVER['SHOPWARE_USAGE_DATA_CONSENT'] = $consent;
-
-        $this->schemaManager->expects($this->once())
-            ->method('introspectTableByUnquotedName')
-            ->with('consent_state')
-            ->willReturn(new Table('consent_state'));
 
         $this->connection->expects($this->once())->method('fetchAssociative')->willReturn(false);
         $this->connection->expects($this->once())->method('executeStatement')->with(
@@ -141,11 +124,6 @@ class UsageDataConsentSubscriberTest extends TestCase
     public function testUpdateNewConsentState(string $consent, string $storedValue, bool $shouldExecute): void
     {
         $_SERVER['SHOPWARE_USAGE_DATA_CONSENT'] = $consent;
-
-        $this->schemaManager->expects($this->once())
-            ->method('introspectTableByUnquotedName')
-            ->with('consent_state')
-            ->willReturn(new Table('consent_state'));
 
         $this->connection->expects($this->once())->method('fetchAssociative')->willReturn([
             'id' => 1,

--- a/tests/Services/OneTimeTasksTest.php
+++ b/tests/Services/OneTimeTasksTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopware\Deployment\Tests\Services;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Deployment\Config\ProjectConfiguration;
@@ -42,8 +43,12 @@ class OneTimeTasksTest extends TestCase
         $processHelper = $this->createMock(ProcessHelper::class);
         $processHelper->expects($this->never())->method('runAndTail');
 
+        $schemaManager = $this->createMock(AbstractSchemaManager::class);
+        $schemaManager->method('tablesExist')->willReturn(false);
+
         $connection = $this->createMock(Connection::class);
-        $connection->expects($this->once())->method('executeQuery')->with('SELECT 1 FROM one_time_tasks LIMIT 1');
+        $connection->method('createSchemaManager')->willReturn($schemaManager);
+        $connection->expects($this->once())->method('executeStatement')->with('CREATE TABLE one_time_tasks (id VARCHAR(255) PRIMARY KEY, created_at DATETIME NOT NULL)');
         $connection->expects($this->once())->method('fetchAllAssociativeIndexed')->willReturn([]);
 
         $configuration = new ProjectConfiguration();
@@ -60,7 +65,11 @@ class OneTimeTasksTest extends TestCase
         $processHelper = $this->createMock(ProcessHelper::class);
         $processHelper->expects($this->once())->method('runAndTail')->with('echo "test"');
 
+        $schemaManager = $this->createMock(AbstractSchemaManager::class);
+        $schemaManager->method('tablesExist')->willReturn(true);
+
         $connection = $this->createMock(Connection::class);
+        $connection->method('createSchemaManager')->willReturn($schemaManager);
         $connection->expects($this->once())->method('fetchAllAssociativeIndexed')->willReturn([]);
 
         $connection->expects($this->once())->method('executeStatement')->with('INSERT INTO one_time_tasks (id, created_at) VALUES (:id, :created_at)', [
@@ -116,7 +125,11 @@ class OneTimeTasksTest extends TestCase
         $processHelper = $this->createMock(ProcessHelper::class);
         $processHelper->expects($this->once())->method('runAndTail')->with('echo "before"');
 
+        $schemaManager = $this->createMock(AbstractSchemaManager::class);
+        $schemaManager->method('tablesExist')->willReturn(true);
+
         $connection = $this->createMock(Connection::class);
+        $connection->method('createSchemaManager')->willReturn($schemaManager);
         $connection->expects($this->once())->method('fetchAllAssociativeIndexed')->willReturn([]);
         $connection->expects($this->once())->method('executeStatement');
 
@@ -138,7 +151,11 @@ class OneTimeTasksTest extends TestCase
         $processHelper = $this->createMock(ProcessHelper::class);
         $processHelper->expects($this->once())->method('runAndTail')->with('echo "after"');
 
+        $schemaManager = $this->createMock(AbstractSchemaManager::class);
+        $schemaManager->method('tablesExist')->willReturn(true);
+
         $connection = $this->createMock(Connection::class);
+        $connection->method('createSchemaManager')->willReturn($schemaManager);
         $connection->expects($this->once())->method('fetchAllAssociativeIndexed')->willReturn([]);
         $connection->expects($this->once())->method('executeStatement');
 
@@ -160,7 +177,11 @@ class OneTimeTasksTest extends TestCase
         $processHelper = $this->createMock(ProcessHelper::class);
         $processHelper->expects($this->exactly(1))->method('runAndTail');
 
+        $schemaManager = $this->createMock(AbstractSchemaManager::class);
+        $schemaManager->method('tablesExist')->willReturn(true);
+
         $connection = $this->createMock(Connection::class);
+        $connection->method('createSchemaManager')->willReturn($schemaManager);
         $connection->expects($this->once())->method('fetchAllAssociativeIndexed')->willReturn([]);
         $connection->expects($this->exactly(1))->method('executeStatement');
 


### PR DESCRIPTION
This pull request refactors how the code checks for the existence of the `consent_state` table in both the implementation and its tests. The main change is replacing the usage of Doctrine's schema introspection with a direct SQL query.

**Refactoring consent table existence check:**

* Replaced the use of `introspectTableByUnquotedName` from Doctrine's schema manager with a direct SQL query (`SELECT 1 FROM consent_state LIMIT 1`) to check if the `consent_state` table exists in `UsageDataConsentSubscriber`. The exception handling was also generalized to `\Throwable` for broader compatibility.

**Test suite simplification and update:**

* Removed all references to `AbstractSchemaManager`, `TableDoesNotExist`, and related mocks from `UsageDataConsentSubscriberTest.php`, as the schema manager is no longer used in the implementation.
* Updated tests to mock and expect `executeQuery` (and its exceptions) on the `Connection` object instead of schema manager methods. 