### PR TITLE
feat: add staging mode support

### DIFF
--- a/src/Config/ConfigFactory.php
+++ b/src/Config/ConfigFactory.php
@@ -31,7 +31,7 @@ class ConfigFactory
         }
 
         if (!file_exists($file)) {
-            return self::fillLicenseDomain(new ProjectConfiguration());
+            return self::fillDefaults(new ProjectConfiguration());
         }
 
         $projectConfiguration = new ProjectConfiguration();
@@ -48,7 +48,7 @@ class ConfigFactory
             self::fillConfig($projectConfiguration, $config['deployment']);
         }
 
-        return self::fillLicenseDomain($projectConfiguration);
+        return self::fillDefaults($projectConfiguration);
     }
 
     /**
@@ -56,6 +56,12 @@ class ConfigFactory
      */
     private static function fillConfig(ProjectConfiguration $projectConfiguration, array $deployment): void
     {
+        if (isset($deployment['staging']) && \is_array($deployment['staging'])) {
+            if (isset($deployment['staging']['enabled']) && \is_bool($deployment['staging']['enabled'])) {
+                $projectConfiguration->staging->enabled = $deployment['staging']['enabled'];
+            }
+        }
+
         if (isset($deployment['maintenance']) && \is_array($deployment['maintenance'])) {
             if (isset($deployment['maintenance']['enabled']) && \is_bool($deployment['maintenance']['enabled'])) {
                 $projectConfiguration->maintenance->enabled = $deployment['maintenance']['enabled'];
@@ -183,12 +189,16 @@ class ConfigFactory
         return null;
     }
 
-    public static function fillLicenseDomain(ProjectConfiguration $projectConfiguration): ProjectConfiguration
+    private static function fillDefaults(ProjectConfiguration $config): ProjectConfiguration
     {
         if (EnvironmentHelper::hasVariable('SHOPWARE_STORE_LICENSE_DOMAIN')) {
-            $projectConfiguration->store->licenseDomain = EnvironmentHelper::getVariable('SHOPWARE_STORE_LICENSE_DOMAIN', '');
+            $config->store->licenseDomain = EnvironmentHelper::getVariable('SHOPWARE_STORE_LICENSE_DOMAIN', '');
         }
 
-        return $projectConfiguration;
+        if (EnvironmentHelper::getVariable('SHOPWARE_DEPLOYMENT_STAGING') === '1') {
+            $config->staging->enabled = true;
+        }
+
+        return $config;
     }
 }

--- a/src/Config/ProjectConfiguration.php
+++ b/src/Config/ProjectConfiguration.php
@@ -12,6 +12,8 @@ class ProjectConfiguration
 
     public ProjectMaintenance $maintenance;
 
+    public ProjectStaging $staging;
+
     public ProjectStore $store;
 
     /**
@@ -26,6 +28,7 @@ class ProjectConfiguration
         $this->hooks = new ProjectHooks();
         $this->extensionManagement = new ProjectExtensionManagement();
         $this->maintenance = new ProjectMaintenance();
+        $this->staging = new ProjectStaging();
         $this->store = new ProjectStore();
     }
 }

--- a/src/Config/ProjectStaging.php
+++ b/src/Config/ProjectStaging.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Deployment\Config;
+
+class ProjectStaging
+{
+    public bool $enabled = false;
+}

--- a/src/Integration/StagingSetupSubscriber.php
+++ b/src/Integration/StagingSetupSubscriber.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Deployment\Integration;
+
+use Shopware\Deployment\Config\ProjectConfiguration;
+use Shopware\Deployment\Event\PostDeploy;
+use Shopware\Deployment\Helper\ProcessHelper;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+#[AsEventListener(event: PostDeploy::class, method: '__invoke')]
+readonly class StagingSetupSubscriber
+{
+    public function __construct(
+        private ProjectConfiguration $projectConfiguration,
+        private ProcessHelper $processHelper,
+    ) {
+    }
+
+    public function __invoke(PostDeploy $event): void
+    {
+        if (!$this->projectConfiguration->staging->enabled) {
+            return;
+        }
+
+        $this->processHelper->console(['system:setup:staging', '--no-interaction', '--force']);
+    }
+}

--- a/src/Services/InstallationManager.php
+++ b/src/Services/InstallationManager.php
@@ -88,6 +88,7 @@ class InstallationManager
         $this->state->disableFirstRunWizard();
 
         $this->processHelper->console(['plugin:refresh']);
+
         $this->pluginHelper->installPlugins($output, $configuration->skipAssetsInstall);
         $this->pluginHelper->updatePlugins($output, $configuration->skipAssetsInstall);
         $this->pluginHelper->deactivatePlugins($output, $configuration->skipAssetsInstall);

--- a/tests/Config/ConfigFactoryTest.php
+++ b/tests/Config/ConfigFactoryTest.php
@@ -84,6 +84,19 @@ class ConfigFactoryTest extends TestCase
         static::assertTrue($config->alwaysClearCache);
     }
 
+    public function testExistingConfigWithStaging(): void
+    {
+        $config = ConfigFactory::create(__DIR__ . '/_fixtures/staging', $this->createMockApplication());
+        static::assertTrue($config->staging->enabled);
+    }
+
+    #[Env('SHOPWARE_DEPLOYMENT_STAGING', '1')]
+    public function testStagingEnvVar(): void
+    {
+        $config = ConfigFactory::create(__DIR__, $this->createMockApplication());
+        static::assertTrue($config->staging->enabled);
+    }
+
     public function testExistingConfigWithExtensionOverride(): void
     {
         $config = ConfigFactory::create(__DIR__ . '/_fixtures/extension-override', $this->createMockApplication());

--- a/tests/Config/_fixtures/staging/.shopware-project.yml
+++ b/tests/Config/_fixtures/staging/.shopware-project.yml
@@ -1,0 +1,3 @@
+deployment:
+  staging:
+    enabled: true

--- a/tests/Integration/StagingSetupSubscriberTest.php
+++ b/tests/Integration/StagingSetupSubscriberTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Deployment\Tests\Integration;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Deployment\Config\ProjectConfiguration;
+use Shopware\Deployment\Config\ProjectStaging;
+use Shopware\Deployment\Event\PostDeploy;
+use Shopware\Deployment\Helper\ProcessHelper;
+use Shopware\Deployment\Integration\StagingSetupSubscriber;
+use Shopware\Deployment\Struct\RunConfiguration;
+use Symfony\Component\Console\Output\NullOutput;
+
+#[CoversClass(StagingSetupSubscriber::class)]
+class StagingSetupSubscriberTest extends TestCase
+{
+    private ProjectConfiguration&MockObject $projectConfiguration;
+    private ProcessHelper&MockObject $processHelper;
+    private StagingSetupSubscriber $subscriber;
+
+    protected function setUp(): void
+    {
+        $this->projectConfiguration = $this->createMock(ProjectConfiguration::class);
+        $this->processHelper = $this->createMock(ProcessHelper::class);
+        $this->subscriber = new StagingSetupSubscriber($this->projectConfiguration, $this->processHelper);
+    }
+
+    public function testInvokeWithStagingEnabled(): void
+    {
+        $this->projectConfiguration->staging = new ProjectStaging();
+        $this->projectConfiguration->staging->enabled = true;
+
+        $this->processHelper
+            ->expects($this->once())
+            ->method('console')
+            ->with(['system:setup:staging', '--no-interaction', '--force']);
+
+        $event = new PostDeploy(new RunConfiguration(), new NullOutput());
+        $this->subscriber->__invoke($event);
+    }
+
+    public function testInvokeWithStagingDisabled(): void
+    {
+        $this->projectConfiguration->staging = new ProjectStaging();
+        $this->projectConfiguration->staging->enabled = false;
+
+        $this->processHelper
+            ->expects($this->never())
+            ->method('console');
+
+        $event = new PostDeploy(new RunConfiguration(), new NullOutput());
+        $this->subscriber->__invoke($event);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `deployment.staging.enabled: true` YAML config option and `SHOPWARE_STAGING=1` env var
- When staging mode is enabled, runs `bin/console system:setup:staging --no-interaction --force` before managing extensions in both install and update flows

Closes #81