### PR TITLE
Add telemetry notice hint to deployment helper commands

### DIFF
--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -43,6 +43,8 @@ class RunCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $this->trackingService->showHint($output);
+
         $installed = $this->state->isInstalled();
         $timeout = $input->getOption('timeout');
 

--- a/src/Services/TrackingService.php
+++ b/src/Services/TrackingService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopware\Deployment\Services;
 
 use Shopware\Deployment\Helper\EnvironmentHelper;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class TrackingService
 {
@@ -13,6 +14,8 @@ class TrackingService
     public const LEGACY_DEPLOYMENT_HELPER_ID = 'core.deployment_helper.id';
 
     private const DEFAULT_TRACKING_DOMAIN = 'udp.usage.shopware.io';
+
+    private const TELEMETRY_DOCS_URL = 'https://github.com/shopware/deployment-helper/blob/main/TELEMETRY.md';
 
     /**
      * @var array<string, string>
@@ -67,6 +70,18 @@ class TrackingService
         if (isset($this->id)) {
             $this->systemConfigHelper->set(self::TELEMETRY_ID, $this->id);
         }
+    }
+
+    public function showHint(OutputInterface $output): void
+    {
+        if (EnvironmentHelper::hasVariable('DO_NOT_TRACK')) {
+            return;
+        }
+
+        $output->writeln(\sprintf(
+            '<comment>Shopware collects anonymous telemetry about your usage of the Deployment Helper. Learn more at %s</comment>',
+            self::TELEMETRY_DOCS_URL,
+        ));
     }
 
     /**

--- a/src/Services/TrackingService.php
+++ b/src/Services/TrackingService.php
@@ -15,7 +15,7 @@ class TrackingService
 
     private const DEFAULT_TRACKING_DOMAIN = 'udp.usage.shopware.io';
 
-    private const TELEMETRY_DOCS_URL = 'https://github.com/shopware/deployment-helper/blob/main/TELEMETRY.md';
+    private const TELEMETRY_DOCS_URL = 'https://developer.shopware.com/docs/resources/references/telemetry.html';
 
     /**
      * @var array<string, string>

--- a/tests/Command/RunCommandTest.php
+++ b/tests/Command/RunCommandTest.php
@@ -51,6 +51,9 @@ class RunCommandTest extends TestCase
 
         $trackingService = $this->createMock(TrackingService::class);
         $trackingService
+            ->expects($this->once())
+            ->method('showHint');
+        $trackingService
             ->expects($this->exactly(2))
             ->method('track')
             ->willReturnCallback(static function ($event, $data): void {
@@ -115,6 +118,9 @@ class RunCommandTest extends TestCase
 
         $trackingService = $this->createMock(TrackingService::class);
         $trackingService
+            ->expects($this->once())
+            ->method('showHint');
+        $trackingService
             ->expects($this->exactly(2))
             ->method('track')
             ->willReturnCallback(static function ($event, $data): void {
@@ -176,6 +182,9 @@ class RunCommandTest extends TestCase
             }));
 
         $trackingService = $this->createMock(TrackingService::class);
+        $trackingService
+            ->expects($this->once())
+            ->method('showHint');
         $trackingService
             ->expects($this->exactly(2))
             ->method('track')

--- a/tests/Services/TrackingServiceTest.php
+++ b/tests/Services/TrackingServiceTest.php
@@ -90,7 +90,7 @@ class TrackingServiceTest extends TestCase
 
         $content = $output->fetch();
         static::assertStringContainsString('Shopware collects anonymous telemetry', $content);
-        static::assertStringContainsString('https://github.com/shopware/deployment-helper/blob/main/TELEMETRY.md', $content);
+        static::assertStringContainsString('https://developer.shopware.com/docs/resources/references/telemetry.html', $content);
     }
 
     #[Env('DO_NOT_TRACK')]

--- a/tests/Services/TrackingServiceTest.php
+++ b/tests/Services/TrackingServiceTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Deployment\Services\ShopwareState;
 use Shopware\Deployment\Services\TrackingService;
 use Shopware\Deployment\Tests\TestUtil\StaticSystemConfigHelper;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Zalas\PHPUnit\Globals\Attribute\Env;
 
 #[CoversClass(TrackingService::class)]
@@ -76,5 +77,32 @@ class TrackingServiceTest extends TestCase
 
         $service = new TrackingService($systemConfigHelper, $shopwareState);
         $service->track('test_event');
+    }
+
+    public function testShowHintPrintsTelemetryNotice(): void
+    {
+        $systemConfigHelper = new StaticSystemConfigHelper();
+        $shopwareState = $this->createMock(ShopwareState::class);
+
+        $service = new TrackingService($systemConfigHelper, $shopwareState);
+        $output = new BufferedOutput();
+        $service->showHint($output);
+
+        $content = $output->fetch();
+        static::assertStringContainsString('Shopware collects anonymous telemetry', $content);
+        static::assertStringContainsString('https://github.com/shopware/deployment-helper/blob/main/TELEMETRY.md', $content);
+    }
+
+    #[Env('DO_NOT_TRACK')]
+    public function testShowHintIsSuppressedByDoNotTrack(): void
+    {
+        $systemConfigHelper = new StaticSystemConfigHelper();
+        $shopwareState = $this->createMock(ShopwareState::class);
+
+        $service = new TrackingService($systemConfigHelper, $shopwareState);
+        $output = new BufferedOutput();
+        $service->showHint($output);
+
+        static::assertSame('', $output->fetch());
     }
 }


### PR DESCRIPTION
## Summary
This PR adds a telemetry notice that informs users about Shopware's anonymous telemetry collection when running deployment commands. The notice is displayed at the start of command execution and can be suppressed via the `DO_NOT_TRACK` environment variable.

## Key Changes
- **TrackingService**: Added `showHint()` method that displays a telemetry notice with a link to documentation
  - The notice is suppressed when the `DO_NOT_TRACK` environment variable is set
  - Added `TELEMETRY_DOCS_URL` constant pointing to the telemetry documentation
- **RunCommand**: Integrated the telemetry hint display at the beginning of command execution
- **Tests**: Added comprehensive test coverage for the new functionality
  - Tests verify the hint is displayed with correct content and documentation link
  - Tests verify the hint is suppressed when `DO_NOT_TRACK` is set
  - Updated existing command tests to expect the `showHint()` method call

## Implementation Details
- The hint is displayed using Symfony's `OutputInterface` with comment formatting
- The implementation respects user privacy preferences via the standard `DO_NOT_TRACK` environment variable
- The telemetry notice is shown once per command execution, before any deployment operations begin

https://claude.ai/code/session_01P7KzEc8dUzo7iRN4Qq1fMN