### PR TITLE
feat: extend isInstalled check with if user and sales channel exists. Add is-installed command.

### DIFF
--- a/src/Command/IsInstalledCommand.php
+++ b/src/Command/IsInstalledCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Deployment\Command;
+
+use Shopware\Deployment\Services\ShopwareState;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand('is-installed', description: 'Check if Shopware is installed', hidden: true)]
+class IsInstalledCommand extends Command
+{
+    public function __construct(
+        private readonly ShopwareState $state,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if ($this->state->isInstalled()) {
+            $output->writeln('Shopware is installed');
+
+            return Command::SUCCESS;
+        }
+
+        $output->writeln('Shopware is not installed');
+
+        return Command::FAILURE;
+    }
+}

--- a/src/Services/ShopwareState.php
+++ b/src/Services/ShopwareState.php
@@ -24,6 +24,16 @@ class ShopwareState
         try {
             $this->connection->fetchAllAssociative('SELECT * FROM system_config');
 
+            $numberOfExistingUsers = (int) $this->connection->fetchOne('SELECT COUNT(*) FROM `user`');
+            if ($numberOfExistingUsers === 0) {
+                return false;
+            }
+
+            $salesChannelExists = (int) $this->connection->fetchOne('SELECT COUNT(*) FROM `sales_channel`');
+            if ($salesChannelExists === 0) {
+                return false;
+            }
+
             return true;
         } catch (\Throwable) {
             return false;

--- a/tests/Command/IsInstalledCommandTest.php
+++ b/tests/Command/IsInstalledCommandTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Deployment\Tests\Command;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Deployment\Command\IsInstalledCommand;
+use Shopware\Deployment\Services\ShopwareState;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(IsInstalledCommand::class)]
+class IsInstalledCommandTest extends TestCase
+{
+    public function testReturnsSuccessWhenInstalled(): void
+    {
+        $state = $this->createMock(ShopwareState::class);
+        $state->method('isInstalled')->willReturn(true);
+
+        $tester = new CommandTester(new IsInstalledCommand($state));
+        $tester->execute([]);
+
+        $tester->assertCommandIsSuccessful();
+        static::assertStringContainsString('Shopware is installed', $tester->getDisplay());
+    }
+
+    public function testReturnsFailureWhenNotInstalled(): void
+    {
+        $state = $this->createMock(ShopwareState::class);
+        $state->method('isInstalled')->willReturn(false);
+
+        $tester = new CommandTester(new IsInstalledCommand($state));
+        $exitCode = $tester->execute([]);
+
+        static::assertSame(Command::FAILURE, $exitCode);
+        static::assertStringContainsString('Shopware is not installed', $tester->getDisplay());
+    }
+}

--- a/tests/Services/ShopwareStateTest.php
+++ b/tests/Services/ShopwareStateTest.php
@@ -33,11 +33,26 @@ class ShopwareStateTest extends TestCase
 
     public function testShopwareIsInstalled(): void
     {
-        $this->connection
-            ->expects($this->once())
-            ->method('fetchAllAssociative')
-            ->willReturn([]);
+        $this->connection->method('fetchAllAssociative')->willReturn([]);
+        $this->connection->method('fetchOne')->willReturn('1');
+
         static::assertTrue($this->state->isInstalled());
+    }
+
+    public function testShopwareIsNotInstalledWhenNoUser(): void
+    {
+        $this->connection->method('fetchAllAssociative')->willReturn([]);
+        $this->connection->method('fetchOne')->willReturnOnConsecutiveCalls('0');
+
+        static::assertFalse($this->state->isInstalled());
+    }
+
+    public function testShopwareIsNotInstalledWhenNoSalesChannel(): void
+    {
+        $this->connection->method('fetchAllAssociative')->willReturn([]);
+        $this->connection->method('fetchOne')->willReturnOnConsecutiveCalls('1', '0');
+
+        static::assertFalse($this->state->isInstalled());
     }
 
     public function testStorefrontInstalled(): void


### PR DESCRIPTION
Closes #5 

Extends the isInstalled() check to verify that at least one user exists in the database and if any sales channel exists. Adds a new is-installed CLI command that exits with code 0 when installed and 1 when not, making it usable in shell scripts.  