### PR TITLE
feat: add optional admin email for the user:create in InstallationManager

### DIFF
--- a/src/Services/InstallationManager.php
+++ b/src/Services/InstallationManager.php
@@ -40,6 +40,7 @@ class InstallationManager
         $shopCurrency = EnvironmentHelper::getVariable('INSTALL_CURRENCY', 'EUR');
         $adminUser = EnvironmentHelper::getVariable('INSTALL_ADMIN_USERNAME', 'admin');
         $adminPassword = EnvironmentHelper::getVariable('INSTALL_ADMIN_PASSWORD', 'shopware');
+        $adminEmail = EnvironmentHelper::getVariable('INSTALL_ADMIN_EMAIL', '');
         $appUrl = EnvironmentHelper::getVariable('APP_URL');
         $salesChannelUrl = UrlHelper::normalizeSalesChannelUrl(EnvironmentHelper::getVariable('SALES_CHANNEL_URL', $appUrl) ?? '');
 
@@ -63,7 +64,12 @@ class InstallationManager
         $this->trackingService->persistId();
         $this->trackingService->track('installed', ['took' => microtime(true) - $took, 'shopware_version' => $this->state->getCurrentVersion()]);
 
-        $this->processHelper->console(['user:create', $adminUser, '--password=' . $adminPassword]);
+        $additionalCreateUserParameters = [];
+        if ($adminEmail !== '') {
+            $additionalCreateUserParameters[] = '--email=' . $adminEmail;
+        }
+
+        $this->processHelper->console(['user:create', $adminUser, '--password=' . $adminPassword, ...$additionalCreateUserParameters]);
 
         $this->processHelper->console(['messenger:setup-transports']);
 

--- a/tests/Services/InstallationManagerTest.php
+++ b/tests/Services/InstallationManagerTest.php
@@ -170,5 +170,35 @@ class InstallationManagerTest extends TestCase
 
         static::assertCount(4, $consoleCommands);
         static::assertSame(['system:install', '--create-database', '--shop-locale=en-GB', '--shop-currency=EUR', '--force', '--no-assign-theme', '--skip-assets-install', '--drop-database'], $consoleCommands[0]);
+        static::assertSame(['user:create', 'admin', '--password=shopware'], $consoleCommands[1]);
+    }
+
+    #[Env('INSTALL_ADMIN_EMAIL', 'admin@example.com')]
+    public function testRunWithAdminEmail(): void
+    {
+        $processHelper = $this->createMock(ProcessHelper::class);
+        $consoleCommands = [];
+
+        $processHelper
+            ->method('console')
+            ->willReturnCallback(static function (array $command) use (&$consoleCommands): void {
+                $consoleCommands[] = $command;
+            });
+
+        $manager = new InstallationManager(
+            $this->createMock(ShopwareState::class),
+            $this->createMock(Connection::class),
+            $processHelper,
+            $this->createMock(PluginHelper::class),
+            $this->createMock(AppHelper::class),
+            $this->createMock(HookExecutor::class),
+            new ProjectConfiguration(),
+            $this->createMock(AccountService::class),
+            $this->createMock(TrackingService::class),
+        );
+
+        $manager->run(new RunConfiguration(), $this->createMock(OutputInterface::class));
+
+        static::assertSame(['user:create', 'admin', '--password=shopware', '--email=admin@example.com'], $consoleCommands[1]);
     }
 }


### PR DESCRIPTION
Adds optional admin email support during installation via INSTALL_ADMIN_EMAIL.

When set, the value is passed to user:create as --email=.... When omitted, the existing command remains unchanged to avoid breaking existing setups. Tests cover both the default behavior and the email-enabled path.