### PR TITLE
Allow project hooks to be defined as multiple titled steps

### DIFF
--- a/src/Config/ConfigFactory.php
+++ b/src/Config/ConfigFactory.php
@@ -143,7 +143,7 @@ class ConfigFactory
      *
      * @return list<HookStep>
      */
-    private static function parseHookSteps(mixed $value): array
+    private static function parseHookSteps(string|array $value): array
     {
         if (\is_string($value)) {
             return $value === '' ? [] : [new HookStep($value)];

--- a/src/Config/ConfigFactory.php
+++ b/src/Config/ConfigFactory.php
@@ -6,6 +6,7 @@ namespace Shopware\Deployment\Config;
 
 use Shopware\Deployment\Application;
 use Shopware\Deployment\Helper\EnvironmentHelper;
+use Shopware\Deployment\Struct\HookStep;
 use Shopware\Deployment\Struct\OneTimeTask;
 use Shopware\Deployment\Struct\OneTimeTaskWhen;
 use Symfony\Component\Filesystem\Path;
@@ -111,29 +112,63 @@ class ConfigFactory
      */
     private static function fillHooks(ProjectHooks $hooks, array $config): void
     {
-        if (isset($config['pre']) && \is_string($config['pre'])) {
-            $hooks->pre = $config['pre'];
+        if (isset($config['pre'])) {
+            $hooks->pre = self::parseHookSteps($config['pre']);
         }
 
-        if (isset($config['post']) && \is_string($config['post'])) {
-            $hooks->post = $config['post'];
+        if (isset($config['post'])) {
+            $hooks->post = self::parseHookSteps($config['post']);
         }
 
-        if (isset($config['pre-install']) && \is_string($config['pre-install'])) {
-            $hooks->preInstall = $config['pre-install'];
+        if (isset($config['pre-install'])) {
+            $hooks->preInstall = self::parseHookSteps($config['pre-install']);
         }
 
-        if (isset($config['post-install']) && \is_string($config['post-install'])) {
-            $hooks->postInstall = $config['post-install'];
+        if (isset($config['post-install'])) {
+            $hooks->postInstall = self::parseHookSteps($config['post-install']);
         }
 
-        if (isset($config['pre-update']) && \is_string($config['pre-update'])) {
-            $hooks->preUpdate = $config['pre-update'];
+        if (isset($config['pre-update'])) {
+            $hooks->preUpdate = self::parseHookSteps($config['pre-update']);
         }
 
-        if (isset($config['post-update']) && \is_string($config['post-update'])) {
-            $hooks->postUpdate = $config['post-update'];
+        if (isset($config['post-update'])) {
+            $hooks->postUpdate = self::parseHookSteps($config['post-update']);
         }
+    }
+
+    /**
+     * A hook can either be a single script (string) or a list of steps with
+     * a "title" and a "script" key, which are executed as individual steps.
+     *
+     * @return list<HookStep>
+     */
+    private static function parseHookSteps(mixed $value): array
+    {
+        if (\is_string($value)) {
+            return $value === '' ? [] : [new HookStep($value)];
+        }
+
+        if (!\is_array($value)) {
+            return [];
+        }
+
+        $steps = [];
+        foreach ($value as $step) {
+            if (\is_array($step) && isset($step['script']) && \is_string($step['script'])) {
+                $title = isset($step['title']) && \is_string($step['title']) ? $step['title'] : '';
+                $steps[] = new HookStep($step['script'], $title);
+
+                continue;
+            }
+
+            // Allow a plain list of script strings as a shorthand.
+            if (\is_string($step) && $step !== '') {
+                $steps[] = new HookStep($step);
+            }
+        }
+
+        return $steps;
     }
 
     /**

--- a/src/Config/ConfigFactory.php
+++ b/src/Config/ConfigFactory.php
@@ -141,16 +141,14 @@ class ConfigFactory
      * A hook can either be a single script (string) or a list of steps with
      * a "title" and a "script" key, which are executed as individual steps.
      *
+     * @param string|array<mixed> $value
+     *
      * @return list<HookStep>
      */
     private static function parseHookSteps(string|array $value): array
     {
         if (\is_string($value)) {
             return $value === '' ? [] : [new HookStep($value)];
-        }
-
-        if (!\is_array($value)) {
-            return [];
         }
 
         $steps = [];

--- a/src/Config/ConfigFactory.php
+++ b/src/Config/ConfigFactory.php
@@ -141,7 +141,7 @@ class ConfigFactory
      * A hook can either be a single script (string) or a list of steps with
      * a "title" and a "script" key, which are executed as individual steps.
      *
-     * @param string|array<mixed> $value
+     * @param string|list<string|array{script?: scalar|null, title?: scalar|null}> $value
      *
      * @return list<HookStep>
      */

--- a/src/Config/ProjectHooks.php
+++ b/src/Config/ProjectHooks.php
@@ -4,15 +4,75 @@ declare(strict_types=1);
 
 namespace Shopware\Deployment\Config;
 
+use Shopware\Deployment\Struct\HookStep;
+
 class ProjectHooks
 {
+    /**
+     * @var list<HookStep>
+     */
+    public array $pre;
+
+    /**
+     * @var list<HookStep>
+     */
+    public array $post;
+
+    /**
+     * @var list<HookStep>
+     */
+    public array $preInstall;
+
+    /**
+     * @var list<HookStep>
+     */
+    public array $postInstall;
+
+    /**
+     * @var list<HookStep>
+     */
+    public array $preUpdate;
+
+    /**
+     * @var list<HookStep>
+     */
+    public array $postUpdate;
+
+    /**
+     * @param string|list<HookStep> $pre
+     * @param string|list<HookStep> $post
+     * @param string|list<HookStep> $preInstall
+     * @param string|list<HookStep> $postInstall
+     * @param string|list<HookStep> $preUpdate
+     * @param string|list<HookStep> $postUpdate
+     */
     public function __construct(
-        public string $pre = '',
-        public string $post = '',
-        public string $preInstall = '',
-        public string $postInstall = '',
-        public string $preUpdate = '',
-        public string $postUpdate = '',
+        string|array $pre = [],
+        string|array $post = [],
+        string|array $preInstall = [],
+        string|array $postInstall = [],
+        string|array $preUpdate = [],
+        string|array $postUpdate = [],
     ) {
+        $this->pre = self::normalize($pre);
+        $this->post = self::normalize($post);
+        $this->preInstall = self::normalize($preInstall);
+        $this->postInstall = self::normalize($postInstall);
+        $this->preUpdate = self::normalize($preUpdate);
+        $this->postUpdate = self::normalize($postUpdate);
+    }
+
+    /**
+     * @param string|list<HookStep> $value
+     *
+     * @return list<HookStep>
+     */
+    private static function normalize(string|array $value): array
+    {
+        if (\is_string($value)) {
+            return $value === '' ? [] : [new HookStep($value)];
+        }
+
+        return $value;
     }
 }

--- a/src/Helper/ProcessHelper.php
+++ b/src/Helper/ProcessHelper.php
@@ -79,12 +79,14 @@ class ProcessHelper
         $this->run(['bin/console', '-n', ...$args]);
     }
 
-    public function runAndTail(string $code): void
+    public function runAndTail(string $code, string $title = ''): void
     {
         $originalCode = $code;
         $code = $this->replaceVariables($code);
 
-        $start = $this->printPreStart([$originalCode]);
+        $label = $title !== '' ? $title : $originalCode;
+
+        $start = $this->printPreStart([$label]);
 
         $process = new Process(['sh', '-c', $code], $this->projectDir);
         $process->setTimeout($this->timeout);
@@ -99,7 +101,7 @@ class ProcessHelper
             throw new \RuntimeException('Execution of ' . $originalCode . ' failed');
         }
 
-        $this->printPostStart([$originalCode], $start);
+        $this->printPostStart([$label], $start);
     }
 
     public function getPluginList(): string

--- a/src/Services/HookExecutor.php
+++ b/src/Services/HookExecutor.php
@@ -27,21 +27,22 @@ class HookExecutor
      */
     public function execute(string $name): void
     {
-        $code = '';
-        match ($name) {
-            self::HOOK_PRE => $code = $this->configuration->hooks->pre,
-            self::HOOK_POST => $code = $this->configuration->hooks->post,
-            self::HOOK_PRE_INSTALL => $code = $this->configuration->hooks->preInstall,
-            self::HOOK_POST_INSTALL => $code = $this->configuration->hooks->postInstall,
-            self::HOOK_PRE_UPDATE => $code = $this->configuration->hooks->preUpdate,
-            self::HOOK_POST_UPDATE => $code = $this->configuration->hooks->postUpdate,
+        $steps = match ($name) {
+            self::HOOK_PRE => $this->configuration->hooks->pre,
+            self::HOOK_POST => $this->configuration->hooks->post,
+            self::HOOK_PRE_INSTALL => $this->configuration->hooks->preInstall,
+            self::HOOK_POST_INSTALL => $this->configuration->hooks->postInstall,
+            self::HOOK_PRE_UPDATE => $this->configuration->hooks->preUpdate,
+            self::HOOK_POST_UPDATE => $this->configuration->hooks->postUpdate,
             default => throw new \RuntimeException('Unknown hook name'),
         };
 
-        if ($code === '') {
-            return;
-        }
+        foreach ($steps as $step) {
+            if ($step->script === '') {
+                continue;
+            }
 
-        $this->processHelper->runAndTail($code);
+            $this->processHelper->runAndTail($step->script, $step->title);
+        }
     }
 }

--- a/src/Struct/HookStep.php
+++ b/src/Struct/HookStep.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Deployment\Struct;
+
+readonly class HookStep
+{
+    public function __construct(
+        public string $script,
+        public string $title = '',
+    ) {
+    }
+}

--- a/tests/Config/ConfigFactoryTest.php
+++ b/tests/Config/ConfigFactoryTest.php
@@ -31,7 +31,7 @@ class ConfigFactoryTest extends TestCase
         static::assertTrue($config->extensionManagement->enabled);
         static::assertSame([], $config->extensionManagement->overrides);
         static::assertSame([], $config->oneTimeTasks);
-        static::assertSame('', $config->hooks->pre);
+        static::assertSame([], $config->hooks->pre);
     }
 
     public static function files(): \Generator
@@ -51,12 +51,31 @@ class ConfigFactoryTest extends TestCase
         static::assertSame('foo', $config->oneTimeTasks['foo']->id);
         static::assertSame('test', $config->oneTimeTasks['foo']->script);
         static::assertSame(OneTimeTaskWhen::AFTER, $config->oneTimeTasks['foo']->when);
-        static::assertNotSame('', $config->hooks->pre);
-        static::assertNotSame('', $config->hooks->post);
-        static::assertNotSame('', $config->hooks->preInstall);
-        static::assertNotSame('', $config->hooks->postInstall);
-        static::assertNotSame('', $config->hooks->preUpdate);
-        static::assertNotSame('', $config->hooks->postUpdate);
+        static::assertNotEmpty($config->hooks->pre);
+        static::assertNotEmpty($config->hooks->post);
+        static::assertNotEmpty($config->hooks->preInstall);
+        static::assertNotEmpty($config->hooks->postInstall);
+        static::assertNotEmpty($config->hooks->preUpdate);
+        static::assertNotEmpty($config->hooks->postUpdate);
+        static::assertStringContainsString('Before deployment general', $config->hooks->pre[0]->script);
+    }
+
+    public function testExistingConfigWithMultiStepHooks(): void
+    {
+        $config = ConfigFactory::create(__DIR__ . '/_fixtures/multi-step-hooks', $this->createMockApplication());
+
+        static::assertCount(2, $config->hooks->post);
+
+        static::assertSame('Warm up the cache', $config->hooks->post[0]->title);
+        static::assertStringContainsString('cache:warmup', $config->hooks->post[0]->script);
+
+        static::assertSame('Notify the team', $config->hooks->post[1]->title);
+        static::assertStringContainsString('notify.sh', $config->hooks->post[1]->script);
+
+        // A plain string hook is still supported and becomes a single untitled step
+        static::assertCount(1, $config->hooks->pre);
+        static::assertSame('', $config->hooks->pre[0]->title);
+        static::assertStringContainsString('Before deployment', $config->hooks->pre[0]->script);
     }
 
     public function testExistingConfigWithMaintenance(): void
@@ -211,10 +230,10 @@ class ConfigFactoryTest extends TestCase
         static::assertSame('local.example.com', $config->store->licenseDomain);
 
         // Local override replaces the pre hook
-        static::assertStringContainsString('Local pre hook', $config->hooks->pre);
+        static::assertStringContainsString('Local pre hook', $config->hooks->pre[0]->script);
 
         // Original post hook is preserved (deep merge)
-        static::assertStringContainsString('After deployment general', $config->hooks->post);
+        static::assertStringContainsString('After deployment general', $config->hooks->post[0]->script);
 
         // One-time tasks are appended (list append)
         static::assertArrayHasKey('foo', $config->oneTimeTasks);
@@ -242,8 +261,8 @@ class ConfigFactoryTest extends TestCase
         $config = ConfigFactory::create(__DIR__ . '/_fixtures/local-override-tag', $this->createMockApplication());
 
         // hooks was fully replaced with !override, post hook should be gone
-        static::assertStringContainsString('Only this hook', $config->hooks->pre);
-        static::assertSame('', $config->hooks->post);
+        static::assertStringContainsString('Only this hook', $config->hooks->pre[0]->script);
+        static::assertSame([], $config->hooks->post);
 
         // Other sections are preserved
         static::assertTrue($config->extensionManagement->enabled);

--- a/tests/Config/ConfigFactoryTest.php
+++ b/tests/Config/ConfigFactoryTest.php
@@ -76,6 +76,12 @@ class ConfigFactoryTest extends TestCase
         static::assertCount(1, $config->hooks->pre);
         static::assertSame('', $config->hooks->pre[0]->title);
         static::assertStringContainsString('Before deployment', $config->hooks->pre[0]->script);
+
+        // A plain list of script strings is the shorthand for untitled steps
+        static::assertCount(2, $config->hooks->preUpdate);
+        static::assertSame('echo "first"', $config->hooks->preUpdate[0]->script);
+        static::assertSame('', $config->hooks->preUpdate[0]->title);
+        static::assertSame('echo "second"', $config->hooks->preUpdate[1]->script);
     }
 
     public function testExistingConfigWithMaintenance(): void

--- a/tests/Config/ProjectConfigurationTest.php
+++ b/tests/Config/ProjectConfigurationTest.php
@@ -10,11 +10,13 @@ use Shopware\Deployment\Config\ProjectConfiguration;
 use Shopware\Deployment\Config\ProjectHooks;
 use Shopware\Deployment\Config\ProjectMaintenance;
 use Shopware\Deployment\Config\ProjectStore;
+use Shopware\Deployment\Struct\HookStep;
 
 #[CoversClass(ProjectConfiguration::class)]
 #[CoversClass(ProjectHooks::class)]
 #[CoversClass(ProjectMaintenance::class)]
 #[CoversClass(ProjectStore::class)]
+#[CoversClass(HookStep::class)]
 class ProjectConfigurationTest extends TestCase
 {
     public function testConstructor(): void
@@ -32,5 +34,30 @@ class ProjectConfigurationTest extends TestCase
         static::assertEmpty($config->extensionManagement->overrides);
 
         static::assertEmpty($config->store->licenseDomain);
+    }
+
+    public function testHooksNormalizeStringIntoSingleUntitledStep(): void
+    {
+        $hooks = new ProjectHooks(pre: 'echo "hi"');
+
+        static::assertCount(1, $hooks->pre);
+        static::assertSame('echo "hi"', $hooks->pre[0]->script);
+        static::assertSame('', $hooks->pre[0]->title);
+    }
+
+    public function testHooksNormalizeEmptyStringIntoNoSteps(): void
+    {
+        $hooks = new ProjectHooks(pre: '');
+
+        static::assertSame([], $hooks->pre);
+    }
+
+    public function testHooksKeepStepListAsIs(): void
+    {
+        $steps = [new HookStep('echo "a"', 'Step A'), new HookStep('echo "b"', 'Step B')];
+
+        $hooks = new ProjectHooks(post: $steps);
+
+        static::assertSame($steps, $hooks->post);
     }
 }

--- a/tests/Config/_fixtures/multi-step-hooks/.shopware-project.yml
+++ b/tests/Config/_fixtures/multi-step-hooks/.shopware-project.yml
@@ -1,0 +1,10 @@
+deployment:
+  hooks:
+    pre: |
+      echo "Before deployment"
+    post:
+      - title: Warm up the cache
+        script: |
+          bin/console cache:warmup
+      - title: Notify the team
+        script: ./notify.sh

--- a/tests/Config/_fixtures/multi-step-hooks/.shopware-project.yml
+++ b/tests/Config/_fixtures/multi-step-hooks/.shopware-project.yml
@@ -8,3 +8,6 @@ deployment:
           bin/console cache:warmup
       - title: Notify the team
         script: ./notify.sh
+    pre-update:
+      - echo "first"
+      - echo "second"

--- a/tests/Services/HookExecutorTest.php
+++ b/tests/Services/HookExecutorTest.php
@@ -11,8 +11,11 @@ use Shopware\Deployment\Config\ProjectConfiguration;
 use Shopware\Deployment\Config\ProjectHooks;
 use Shopware\Deployment\Helper\ProcessHelper;
 use Shopware\Deployment\Services\HookExecutor;
+use Shopware\Deployment\Struct\HookStep;
 
 #[CoversClass(HookExecutor::class)]
+#[CoversClass(ProjectHooks::class)]
+#[CoversClass(HookStep::class)]
 class HookExecutorTest extends TestCase
 {
     public function testDoesNotWhenEmpty(): void
@@ -22,7 +25,7 @@ class HookExecutorTest extends TestCase
 
         $executor = new HookExecutor($processHelper, $configuration);
 
-        $processHelper->expects($this->never())->method('run');
+        $processHelper->expects($this->never())->method('runAndTail');
 
         $executor->execute(HookExecutor::HOOK_PRE);
     }
@@ -49,9 +52,54 @@ class HookExecutorTest extends TestCase
         $configuration->hooks = $config;
         $executor = new HookExecutor($processHelper, $configuration);
 
-        $processHelper->expects($this->once())->method('runAndTail')->with('Hello World');
+        $processHelper->expects($this->once())->method('runAndTail')->with('Hello World', '');
 
         $executor->execute($hookName);
+    }
+
+    public function testRunsMultipleStepsInOrder(): void
+    {
+        $processHelper = $this->createMock(ProcessHelper::class);
+        $configuration = new ProjectConfiguration();
+
+        $configuration->hooks = new ProjectHooks(post: [
+            new HookStep('echo first', 'First step'),
+            new HookStep('echo second', 'Second step'),
+        ]);
+
+        $executor = new HookExecutor($processHelper, $configuration);
+
+        $calls = [];
+        $processHelper
+            ->expects($this->exactly(2))
+            ->method('runAndTail')
+            ->willReturnCallback(static function (string $script, string $title) use (&$calls): void {
+                $calls[] = [$script, $title];
+            });
+
+        $executor->execute(HookExecutor::HOOK_POST);
+
+        static::assertSame([
+            ['echo first', 'First step'],
+            ['echo second', 'Second step'],
+        ], $calls);
+    }
+
+    public function testSkipsStepsWithEmptyScript(): void
+    {
+        $processHelper = $this->createMock(ProcessHelper::class);
+        $configuration = new ProjectConfiguration();
+
+        $configuration->hooks = new ProjectHooks(post: [
+            new HookStep('', 'Empty step'),
+            new HookStep('echo run', 'Real step'),
+        ]);
+
+        $executor = new HookExecutor($processHelper, $configuration);
+
+        $processHelper->expects($this->once())->method('runAndTail')->with('echo run', 'Real step');
+
+        $executor->execute(HookExecutor::HOOK_POST);
     }
 
     public function testThrowsOnUnknownHook(): void


### PR DESCRIPTION
## What

Project hooks (`pre`, `post`, `pre-install`, `post-install`, `pre-update`, `post-update`) previously accepted only a single script per hook. They can now optionally be defined as a **list of titled steps**, each executed as its own process. The step `title` is shown in the execution banner, so the output makes it obvious which step is running.

## Why

A single hook often bundles several unrelated commands into one script. When something fails or you're watching a deployment, it's hard to tell which part is running or where it broke. Splitting a hook into named steps gives clearer, per-step output ("oversability") without changing how hooks fundamentally work.

## Config

The existing single-script form is unchanged and fully supported:

```yaml
deployment:
  hooks:
    pre: |
      echo "Before deployment"
```

A hook can now also be a list of steps with a `title` and a `script`:

```yaml
deployment:
  hooks:
    post:
      - title: Warm up the cache
        script: |
          bin/console cache:warmup
      - title: Notify the team
        script: ./notify.sh
```

A plain list of strings works as a shorthand for untitled steps:

```yaml
deployment:
  hooks:
    pre-update:
      - echo "first"
      - echo "second"
```

## How

- New `Struct\HookStep` value object (`script` + optional `title`). Lives in `Struct` so it is excluded from the DI container, like `OneTimeTask`.
- `ProjectHooks` now holds `list<HookStep>` per hook. The constructor still accepts a plain string and normalizes it into a single untitled step, keeping backwards compatibility.
- `ConfigFactory::parseHookSteps()` parses all three forms (string / list of `{title, script}` / list of strings). Invalid entries are skipped.
- `HookExecutor::execute()` iterates the steps and runs each, skipping empty scripts.
- `ProcessHelper::runAndTail()` gained an optional `$title` used in the start/end banner (falls back to the script when no title is given).

## Backwards compatibility

Fully backwards compatible — string hooks behave exactly as before and are normalized to a single step internally.

## Testing

- `phpunit`: 264 tests pass; all new hook-parsing branches are covered (`ConfigFactory`, `ProjectHooks`, `HookStep` at 100% line/method coverage).
- `phpstan` (level 8): no errors.
- `php-cs-fixer`: clean.

> [!NOTE]
> The hook config is documented externally on developer.shopware.com, which is not part of this repo. The docs there should be updated separately to mention the multi-step form.
